### PR TITLE
Import layers.scss from type.scss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-guide
 
+## 10.1.1
+
+* 🐛 Fix missing import in type.scss
+
 ## 10.1.0
 
 * 👍 Add border color variables.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -1,4 +1,5 @@
 @import 'color';
+@import 'layers';
 
 $ca-grid: 1.5rem; // 24px @ default root font-size of 16px
 


### PR DESCRIPTION
This PR is about fixing an error that I found when importing: `debug-vertical-rhythm-grid` mixin.
The error appears to be that we are missing `layers.scss` file from `type.scss`. So this PR is just to add the missing dependency