### PR TITLE
Feature/ideal sans touchups

### DIFF
--- a/guide/src/html.js
+++ b/guide/src/html.js
@@ -27,7 +27,7 @@ module.exports = class HTML extends React.Component {
           <link
             rel="stylesheet"
             type="text/css"
-            href="https://cloud.typography.com/6384974/640188/css/fonts.css"
+            href="https://d1vmr11cgrgrrj.cloudfront.net/6743792/css/fonts.css"
           />
           <meta charSet="utf-8" />
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />

--- a/guide/src/layouts/index.js
+++ b/guide/src/layouts/index.js
@@ -12,6 +12,7 @@ import styles from './layout.module.scss';
 class TemplateWrapper extends React.Component {
   state = {
     navOpen: false,
+    showGrid: false,
   };
 
   render() {
@@ -38,7 +39,7 @@ class TemplateWrapper extends React.Component {
             <MainNav openNav={() => this.openNav()} />
           </div>
           <div className={styles.subnav}>
-            <SubNav title="What" closeNav={() => this.closeNav()} />
+            <SubNav closeNav={() => this.closeNav()} />
           </div>
           <div
             className={styles.subnavBackdrop}
@@ -47,10 +48,23 @@ class TemplateWrapper extends React.Component {
           <div className={styles.header}>
             <HeaderBar toggleNav={() => this.toggleNav()} />
           </div>
-          <div className={styles.content}>
+          <div
+            className={classNames(styles.content, {
+              [styles.baselineGrid]: this.state.showGrid,
+            })}
+          >
             <div className={styles.pageContainer}>
               <Breadcrumb />
               {children()}
+              <div className={styles.footer}>
+                &copy; Culture Amp 2018.
+                <button
+                  onClick={() => this.toggleGrid()}
+                  className={styles.footerButton}
+                >
+                  Toggle Baseline Grid
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -60,6 +74,10 @@ class TemplateWrapper extends React.Component {
 
   toggleNav() {
     this.setState({ navOpen: !this.state.navOpen });
+  }
+
+  toggleGrid() {
+    this.setState({ showGrid: !this.state.showGrid });
   }
 
   closeNav() {

--- a/guide/src/layouts/layout.module.scss
+++ b/guide/src/layouts/layout.module.scss
@@ -49,6 +49,19 @@ $transitionSpeed: 200ms;
   max-width: 960px;
   padding: $ca-grid;
   clear: both;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100% - #{$ca-navigation-bar__width});
+}
+.footer {
+  @include ca-type-ideal-small;
+  margin-top: auto;
+  display: block;
+  height: $ca-grid;
+}
+.footerButton {
+  @include ca-inherit-baseline;
+  composes: buttonLink from 'components/HtmlContent.module.scss';
 }
 
 // Note, if the browser doesn't support CSS Grids, we leave them on the mobile view as a fallback.
@@ -159,4 +172,8 @@ $transitionSpeed: 200ms;
       }
     }
   }
+}
+
+.baselineGrid {
+  @include debug-vertical-rhythm-grid;
 }

--- a/guide/src/layouts/layout.module.scss
+++ b/guide/src/layouts/layout.module.scss
@@ -60,8 +60,11 @@ $transitionSpeed: 200ms;
   height: $ca-grid;
 }
 .footerButton {
+  composes: buttonReset from 'components/HtmlContent.module.scss';
+  composes: link from 'components/HtmlContent.module.scss';
+  @include ca-type-ideal-small;
   @include ca-inherit-baseline;
-  composes: buttonLink from 'components/HtmlContent.module.scss';
+  padding: 0 2px;
 }
 
 // Note, if the browser doesn't support CSS Grids, we leave them on the mobile view as a fallback.

--- a/guide/src/pages/styles/_TypographyShowcase.js
+++ b/guide/src/pages/styles/_TypographyShowcase.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import styles from './_TypographyShowcase.module.scss';
+
+class TypographyItem extends React.Component {
+  state = {};
+
+  componentDidMount() {
+    let style = window.getComputedStyle(this.paragraph);
+    this.setState({
+      size: `${style.fontSize} / ${style.lineHeight}`,
+    });
+  }
+
+  render() {
+    let { name, sampleText, className, sassCode } = this.props;
+    let title = this.state.size ? `${name} – ${this.state.size}` : name;
+    return (
+      <div className={styles.typographyShowcaseItem}>
+        <h3>{title}</h3>
+        <p ref={p => (this.paragraph = p)} className={styles[className]}>
+          {sampleText}
+        </p>
+        <pre>{sassCode}</pre>
+      </div>
+    );
+  }
+}
+
+const TypographyShowcase = () => (
+  <div>
+    <h2 className={styles.display}>Type hierarchy</h2>
+    <TypographyItem
+      name="Page Title (H1)"
+      sampleText="Have the courage to be vulnerable"
+      className="pageTitle"
+      sassCode="@include ca-type-ideal-page-title;"
+    />
+    <TypographyItem
+      name="Title (H2)"
+      sampleText="Have the courage to be vulnerable"
+      className="title"
+      sassCode="@include ca-type-ideal-title;"
+    />
+    <TypographyItem
+      name="Display (H3)"
+      sampleText="Learn faster through feedback"
+      className="display"
+      sassCode="@include ca-type-ideal-display;"
+    />
+    <TypographyItem
+      name="Heading (H4)"
+      sampleText="Trust people to make decisions"
+      className="heading"
+      sassCode="@include ca-type-ideal-heading;"
+    />
+    <TypographyItem
+      name="Lede (Intro)"
+      sampleText="Values are not what you want to be on a good day. Values are what you are willing to hurt for every day."
+      className="lede"
+      sassCode="@include ca-type-ideal-lede;"
+    />
+    <TypographyItem
+      name="Body"
+      sampleText="Dr. Brené Brown, author of Daring Greatly, is a research professor from the University of Houston who studies human emotions, including shame and vulnerability. In a March 2012 TED talk, she said, “Vulnerability is not weakness, and that myth is profoundly dangerous.” She went on to say that after 12 years of research, she has actually determined that vulnerability is “our most accurate measurement of courage.”"
+      className="body"
+      sassCode="@include ca-type-ideal-body;"
+    />
+    <TypographyItem
+      name="Body Bold"
+      sampleText="Our mission is to make the power of people analytics accessible to everyone."
+      className="bodyBold"
+      sassCode="@include ca-type-ideal-body-bold;"
+    />
+    <TypographyItem
+      name="Small"
+      sampleText="Had I the heaven's embroidered cloths. Enwrought with golden and silver light. The blue and the dim and the dark cloths of night and light and the half-light. I would spread the cloths under your feet. But I, being poor, have only my dreams. I have spread my dreams under your feet. Tread softly because you tread on my dreams."
+      className="small"
+      sassCode="@include ca-type-ideal-small;"
+    />
+    <TypographyItem
+      name="Small Bold"
+      sampleText="Had I the heaven's embroidered cloths. Enwrought with golden and silver light. The blue and the dim and the dark cloths of night and light and the half-light. I would spread the cloths under your feet. But I, being poor, have only my dreams. I have spread my dreams under your feet. Tread softly because you tread on my dreams."
+      className="smallBold"
+      sassCode="@include ca-type-ideal-small-bold;"
+    />
+    <TypographyItem
+      name="Pre"
+      sampleText="@import 'cultureamp-style-guide/styles/type';"
+      className="pre"
+      sassCode="@include ca-type-pre;"
+    />
+    <TypographyItem
+      name="Pre Bold"
+      sampleText="@import 'cultureamp-style-guide/styles/color';"
+      className="preBold"
+      sassCode="@include ca-type-pre-bold;"
+    />
+    <TypographyItem
+      name="Notifications"
+      sampleText={
+        <span>
+          "Had I the heaven's embroidered cloths.
+          <br />Enwrought with golden and silver light.
+          <br />The blue and the dim and the dark cloths of night and light and
+          the half-light.
+          <br />I would spread the cloths under your feet.
+          <br />But I, being poor, have only my dreams.
+          <br />I have spread my dreams under your feet.
+          <br />Tread softly because you tread on my dreams."
+          <br />&mdash; William Butler Yeats
+        </span>
+      }
+      className="notification"
+      sassCode="@include ca-type-ideal-notification;"
+    />
+    <TypographyItem
+      name="Labels"
+      sampleText="Fact &amp; Truth"
+      className="label"
+      sassCode="@include ca-type-ideal-label;"
+    />
+    <TypographyItem
+      name="Control Action"
+      sampleText="Fact &amp; Truth"
+      className="controlAction"
+      sassCode="@include ca-type-ideal-control-action;"
+    />
+    <TypographyItem
+      name="Buttons"
+      sampleText="Amplify Others"
+      className="button"
+      sassCode="@include ca-type-ideal-button;"
+    />
+  </div>
+);
+
+export default TypographyShowcase;

--- a/guide/src/pages/styles/_TypographyShowcase.module.scss
+++ b/guide/src/pages/styles/_TypographyShowcase.module.scss
@@ -1,0 +1,86 @@
+@import '~cultureamp-style-guide/styles/type';
+@import '~cultureamp-style-guide/styles/border';
+
+.pageTitle {
+  @include ca-type-ideal-page-title;
+  margin: $ca-grid * 1.5 0;
+}
+
+.title {
+  @include ca-type-ideal-title;
+  margin: $ca-grid * 1.5 0;
+}
+
+.display {
+  @include ca-type-ideal-display;
+  margin: $ca-grid 0;
+}
+
+.heading {
+  @include ca-type-ideal-heading;
+}
+
+.lede {
+  @include ca-type-ideal-lede;
+}
+
+.body {
+  @include ca-type-ideal-body;
+}
+
+.bodyBold {
+  @include ca-type-ideal-body-bold;
+}
+
+.small {
+  @include ca-type-ideal-small;
+}
+
+.smallBold {
+  @include ca-type-ideal-small-bold;
+}
+
+.pre {
+  @include ca-type-pre;
+}
+
+.preBold {
+  @include ca-type-pre-bold;
+}
+
+.notification {
+  @include ca-type-ideal-notification;
+}
+
+.label {
+  @include ca-type-ideal-label;
+}
+
+.controlAction {
+  @include ca-type-ideal-control-action;
+}
+
+.button {
+  @include ca-type-ideal-button;
+}
+
+.typographyShowcaseItem {
+  margin-bottom: $ca-grid * 2;
+  h3 {
+    @include ca-type-ideal-body;
+    margin-bottom: $ca-grid;
+  }
+  p {
+    margin: 0 0 $ca-grid 0;
+  }
+  pre {
+    @include ca-type-body;
+    white-space: pre;
+    background: $ca-palette-ink;
+    color: white;
+    border-radius: $ca-border-radius;
+    padding: $ca-grid * 0.5;
+    margin-top: $ca-grid * 0.5;
+    margin-bottom: $ca-grid * 0.5;
+  }
+}

--- a/guide/src/pages/styles/typography.md
+++ b/guide/src/pages/styles/typography.md
@@ -2,6 +2,7 @@
 imports:
   Link: components/Link.js
   IntroParagraph: components/IntroParagraph.js
+  TypographyShowcase: ./_TypographyShowcase.js
   "{TipContainer,TipCard}": components/tip-card
 ---
 
@@ -12,6 +13,8 @@ imports:
 Typography is important when establishing a strong design system. When established, it can help to create balance and hierarchy of textual information. By creating structure within a page, text becomes enjoyable and appealing to read. We aim to ensure type within our product complies with WCAG 2.0 AA standards.
 
 </IntroParagraph>
+
+<TypographyShowcase />
 
 ## What is its purpose?
 

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -25,7 +25,6 @@ $ca-ideal-sans-font-descender-height: 0.14;
   $family: $ca-default-font-family,
   $base-size: $ca-default-font-base-size,
   $descender-height: $ca-default-font-descender-height,
-
   $size-ratio: 1,
   $line-height-in-grid-units: 1,
   $weight: $ca-weight-book,
@@ -53,6 +52,8 @@ $ca-ideal-sans-font-descender-height: 0.14;
   position: static;
 }
 
+// Open Sans Styles
+
 @mixin ca-type-title($args...) {
   @include ca-type(
     $size-ratio: 12/7,
@@ -62,130 +63,141 @@ $ca-ideal-sans-font-descender-height: 0.14;
   );
 }
 
-@mixin ca-type-ideal-title($args...) {
-  @include ca-type-title(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
-    $args...
-  );
+@mixin ca-type-ideal-small-bold($args...) {
+  @include ca-type-ideal-small;
+  font-weight: $ca-weight-semibold;
 }
 
 @mixin ca-type-display($args...) {
-  @include ca-type(
-    $size-ratio: 10/7,
-    $weight: $ca-weight-medium,
-    $args...
-  );
-}
-
-@mixin ca-type-ideal-display($args...) {
-  @include ca-type-display(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
-    $args...
-  );
+  @include ca-type($size-ratio: 10/7, $weight: $ca-weight-medium, $args...);
 }
 
 @mixin ca-type-heading($args...) {
-  @include ca-type(
-    $size-ratio: 8/7,
-    $weight: $ca-weight-medium,
-    $args...
-  );
-}
-
-@mixin ca-type-ideal-heading($args...) {
-  @include ca-type-heading(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
-    $args...
-  );
+  @include ca-type($size-ratio: 8/7, $weight: $ca-weight-medium, $args...);
 }
 
 @mixin ca-type-lede($args...) {
-  @include ca-type(
-    $size-ratio: 8/7,
-    $args...
-  );
-}
-
-@mixin ca-type-ideal-lede($args...) {
-  @include ca-type-lede(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
-    $weight: $ca-weight-light,
-    $args...
-    );
+  @include ca-type($size-ratio: 8/7, $args...);
 }
 
 @mixin ca-type-body($args...) {
   @include ca-type($args...);
 }
 
-@mixin ca-type-ideal-body($args...) {
-  @include ca-type-body(
+@mixin ca-type-control-action($args...) {
+  @include ca-type($weight: $ca-weight-medium, $args...);
+}
+
+@mixin ca-type-small($args...) {
+  @include ca-type($size-ratio: 6/7, $args...);
+}
+
+@mixin ca-type-labels-and-legends($args...) {
+  @include ca-type($size-ratio: 6/7, $letter-spacing: 0.04em, $args...);
+  text-transform: uppercase;
+}
+
+// Ideal Sans styles
+
+@mixin ca-type-ideal($size, $weight, $line-height-in-grid-units: 1, $args...) {
+  @include ca-type(
+    $size-ratio: $size / 16,
     $family: $ca-ideal-sans-font-family,
     $base-size: $ca-ideal-sans-font-base-size,
     $descender-height: $ca-ideal-sans-font-descender-height,
-    $weight: $ca-weight-light,
+    $line-height-in-grid-units: $line-height-in-grid-units,
+    $weight: $weight,
     $args...
   );
 }
 
-@mixin ca-type-control-action($args...) {
-  @include ca-type(
+@mixin ca-type-ideal-page-title($args...) {
+  @include ca-type-ideal(
+    $size: 32,
+    $line-height-in-grid-units: 1.5,
     $weight: $ca-weight-medium,
     $args...
   );
 }
 
-@mixin ca-type-ideal-control-action($args...) {
-  @include ca-type-control-action(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
+@mixin ca-type-ideal-title($args...) {
+  @include ca-type-ideal(
+    $size: 26,
+    $line-height-in-grid-units: 1.5,
+    $weight: $ca-weight-medium,
     $args...
   );
 }
 
-@mixin ca-type-small($args...) {
-  @include ca-type(
-    $size-ratio: 6/7,
-    $args...
-  );
+@mixin ca-type-ideal-display($args...) {
+  @include ca-type-ideal($size: 21, $weight: $ca-weight-medium, $args...);
+}
+
+@mixin ca-type-ideal-heading($args...) {
+  @include ca-type-ideal($size: 18, $weight: $ca-weight-medium, $args...);
+}
+
+@mixin ca-type-ideal-lede($args...) {
+  @include ca-type-ideal($size: 20, $weight: $ca-weight-light, $args...);
+}
+
+@mixin ca-type-ideal-body($args...) {
+  @include ca-type-ideal($size: 16, $weight: $ca-weight-light, $args...);
+}
+
+@mixin ca-type-ideal-body-bold($args...) {
+  @include ca-type-ideal($size: 16, $weight: $ca-weight-medium, $args...);
 }
 
 @mixin ca-type-ideal-small($args...) {
-  @include ca-type-small(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
+  @include ca-type-ideal($size: 14, $weight: $ca-weight-light, $args...);
+}
+
+@mixin ca-type-ideal-small-bold($args...) {
+  @include ca-type-ideal($size: 14, $weight: $ca-weight-medium, $args...);
+}
+
+@mixin ca-type-ideal-notification($args...) {
+  @include ca-type-ideal(
+    $size: 15,
     $weight: $ca-weight-light,
+    $line-height-in-grid-units: 3/4,
     $args...
   );
 }
 
-@mixin ca-type-labels-and-legends($args...) {
-  @include ca-type(
-    $size-ratio: 6/7,
-    $letter-spacing: 0.04em,
-    $args...
-  );
+@mixin ca-type-ideal-label($args...) {
+  @include ca-type-ideal($size: 12, $weight: $ca-weight-medium, $args...);
   text-transform: uppercase;
 }
 
+// Deprecated, use ca-type-ideal-label instead.
 @mixin ca-type-ideal-labels-and-legends($args...) {
-  @include ca-type-labels-and-legends(
-    $family: $ca-ideal-sans-font-family,
-    $base-size: $ca-ideal-sans-font-base-size,
-    $descender-height: $ca-ideal-sans-font-descender-height,
-    $weight: $ca-weight-light,
-    $args...
-  );
+  @include ca-type-ideal-label($args...);
+}
+
+@mixin ca-type-ideal-control-action($args...) {
+  @include ca-type-ideal($size: 16, $weight: $ca-weight-medium, $args...);
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+}
+
+@mixin ca-type-ideal-button($args...) {
+  @include ca-type-ideal($size: 18, $weight: $ca-weight-medium, $args...);
+}
+
+// Operator Mono styles
+
+@mixin ca-type-pre($args...) {
+  // TODO: set up operator mono font
+  @include ca-type-body;
+  white-space: pre;
+}
+
+@mixin ca-type-pre-bold($args...) {
+  // TODO: set up operator mono font
+  @include ca-type-ideal-body-bold;
+  white-space: pre;
 }
 
 @mixin debug-vertical-rhythm-grid() {


### PR DESCRIPTION
- Use new font-microservice
- Add a footer with a button for toggling the baseline grid display
- Update type styles to match naming and sizes in latest sketch file
- Create a "typography showcase" that is somewhat similar to Marc's original design

Note: this changes the styling of fonts using `ca-type-ideal-*` mixins, but these aren't being used in murmur yet so I'm not calling it a breaking change.