### PR TITLE
Type touchups, hide "pre" types, 10.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-guide
 
+## 10.2.0
+
+* ✨ Update all Ideal Sans type styles to the latest in the style guide.
+
 ## 10.1.1
 
 * 🐛 Fix missing import in type.scss

--- a/guide/src/pages/styles/_TypographyShowcase.js
+++ b/guide/src/pages/styles/_TypographyShowcase.js
@@ -84,18 +84,6 @@ const TypographyShowcase = () => (
       sassCode="@include ca-type-ideal-small-bold;"
     />
     <TypographyItem
-      name="Pre"
-      sampleText="@import 'cultureamp-style-guide/styles/type';"
-      className="pre"
-      sassCode="@include ca-type-pre;"
-    />
-    <TypographyItem
-      name="Pre Bold"
-      sampleText="@import 'cultureamp-style-guide/styles/color';"
-      className="preBold"
-      sassCode="@include ca-type-pre-bold;"
-    />
-    <TypographyItem
       name="Notifications"
       sampleText={
         <span>

--- a/guide/src/pages/styles/_TypographyShowcase.module.scss
+++ b/guide/src/pages/styles/_TypographyShowcase.module.scss
@@ -40,14 +40,6 @@
   @include ca-type-ideal-small-bold;
 }
 
-.pre {
-  @include ca-type-pre;
-}
-
-.preBold {
-  @include ca-type-pre-bold;
-}
-
 .notification {
   @include ca-type-ideal-notification;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -99,13 +99,20 @@ $ca-ideal-sans-font-descender-height: 0.14;
 
 // Ideal Sans styles
 
-@mixin ca-type-ideal($size, $weight, $line-height-in-grid-units: 1, $args...) {
+@mixin ca-type-ideal(
+  $size,
+  $weight,
+  $line-height-in-grid-units: 1,
+  $letter-spacing: normal,
+  $args...
+) {
   @include ca-type(
     $size-ratio: $size / 16,
     $family: $ca-ideal-sans-font-family,
     $base-size: $ca-ideal-sans-font-base-size,
     $descender-height: $ca-ideal-sans-font-descender-height,
     $line-height-in-grid-units: $line-height-in-grid-units,
+    $letter-spacing: $letter-spacing,
     $weight: $weight,
     $args...
   );
@@ -130,7 +137,7 @@ $ca-ideal-sans-font-descender-height: 0.14;
 }
 
 @mixin ca-type-ideal-display($args...) {
-  @include ca-type-ideal($size: 21, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 22, $weight: $ca-weight-medium, $args...);
 }
 
 @mixin ca-type-ideal-heading($args...) {
@@ -167,7 +174,14 @@ $ca-ideal-sans-font-descender-height: 0.14;
 }
 
 @mixin ca-type-ideal-label($args...) {
-  @include ca-type-ideal($size: 12, $weight: $ca-weight-medium, $args...);
+  $letter-spacing-in-px: 0.5;
+  $size: 12;
+  @include ca-type-ideal(
+    $size: $size,
+    $weight: $ca-weight-medium,
+    $letter-spacing: $letter-spacing-in-px / $size * 1em,
+    $args...
+  );
   text-transform: uppercase;
 }
 

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -200,20 +200,6 @@ $ca-ideal-sans-font-descender-height: 0.14;
   @include ca-type-ideal($size: 18, $weight: $ca-weight-medium, $args...);
 }
 
-// Operator Mono styles
-
-@mixin ca-type-pre($args...) {
-  // TODO: set up operator mono font
-  @include ca-type-body;
-  white-space: pre;
-}
-
-@mixin ca-type-pre-bold($args...) {
-  // TODO: set up operator mono font
-  @include ca-type-ideal-body-bold;
-  white-space: pre;
-}
-
 @mixin debug-vertical-rhythm-grid() {
   position: relative;
   &:after {


### PR DESCRIPTION
- Fix h3 to be 22px, (before was incorrectly 21px)
- Fix labels to have letter-spacing of 0.5px (but in em, not px)
- Remove "pre" types until we properly define them
- Release 10.2.0 for NPM