### PR TITLE
Use new font bundle, lighter heading weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-guide
 
+## 12.0.2
+
+* 👍 Use "Book" weight for headings and other type styles. We recommend using the new typography bundle at https://d1vmr11cgrgrrj.cloudfront.net/7095992/css/fonts.css to load these fonts.
+
 ## 12.0.1
 
 * 👍 Give control actions a pointer cursor.

--- a/components/NavigationBar/components/Badge.module.scss
+++ b/components/NavigationBar/components/Badge.module.scss
@@ -4,7 +4,7 @@
 .badge {
   background-color: $ca-palette-coral;
   color: #fff;
-  font-weight: $ca-weight-semibold;
+  font-weight: $ca-weight-medium;
   text-decoration: none;
   text-transform: uppercase;
 

--- a/guide/src/components/Demo.module.scss
+++ b/guide/src/components/Demo.module.scss
@@ -57,5 +57,5 @@
 }
 
 .dimension {
-  font-weight: $ca-weight-semibold;
+  font-weight: $ca-weight-medium;
 }

--- a/guide/src/components/HtmlContent.module.scss
+++ b/guide/src/components/HtmlContent.module.scss
@@ -52,7 +52,7 @@
 .h5,
 .htmlContent h5 {
   @include ca-type-ideal-body;
-  font-weight: $ca-weight-semibold;
+  font-weight: $ca-weight-medium;
   margin-top: 0;
   margin-bottom: $ca-grid;
 }

--- a/guide/src/html.js
+++ b/guide/src/html.js
@@ -27,7 +27,7 @@ module.exports = class HTML extends React.Component {
           <link
             rel="stylesheet"
             type="text/css"
-            href="https://d1vmr11cgrgrrj.cloudfront.net/6743792/css/fonts.css"
+            href="https://d1vmr11cgrgrrj.cloudfront.net/7095992/css/fonts.css"
           />
           <meta charSet="utf-8" />
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />

--- a/guide/src/pages/styles/_TypographyShowcase.js
+++ b/guide/src/pages/styles/_TypographyShowcase.js
@@ -16,9 +16,8 @@ class TypographyItem extends React.Component {
     let title = this.state.size ? `${name} – ${this.state.size}` : name;
     return (
       <div className={styles.typographyShowcaseItem}>
-        <h3>{title}</h3>
         <p ref={p => (this.paragraph = p)} className={styles[className]}>
-          {sampleText}
+          {title}
         </p>
         <pre>{sassCode}</pre>
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -122,7 +122,7 @@ $ca-ideal-sans-font-descender-height: 0.14;
   @include ca-type-ideal(
     $size: 32,
     $line-height-in-grid-units: 1.5,
-    $weight: $ca-weight-medium,
+    $weight: $ca-weight-book,
     $args...
   );
 }
@@ -131,17 +131,17 @@ $ca-ideal-sans-font-descender-height: 0.14;
   @include ca-type-ideal(
     $size: 26,
     $line-height-in-grid-units: 1.5,
-    $weight: $ca-weight-medium,
+    $weight: $ca-weight-book,
     $args...
   );
 }
 
 @mixin ca-type-ideal-display($args...) {
-  @include ca-type-ideal($size: 22, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 22, $weight: $ca-weight-book, $args...);
 }
 
 @mixin ca-type-ideal-heading($args...) {
-  @include ca-type-ideal($size: 18, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 18, $weight: $ca-weight-book, $args...);
 }
 
 @mixin ca-type-ideal-lede($args...) {
@@ -153,7 +153,7 @@ $ca-ideal-sans-font-descender-height: 0.14;
 }
 
 @mixin ca-type-ideal-body-bold($args...) {
-  @include ca-type-ideal($size: 16, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 16, $weight: $ca-weight-book, $args...);
 }
 
 @mixin ca-type-ideal-small($args...) {
@@ -161,7 +161,7 @@ $ca-ideal-sans-font-descender-height: 0.14;
 }
 
 @mixin ca-type-ideal-small-bold($args...) {
-  @include ca-type-ideal($size: 14, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 14, $weight: $ca-weight-book, $args...);
 }
 
 @mixin ca-type-ideal-notification($args...) {


### PR DESCRIPTION
And don't use sample text on the typography page until we have a nicer design. Using the title for now is much easier to read.