### PR TITLE
Dropdown component:: Make label prop optional

### DIFF
--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -13,7 +13,7 @@ type DropdownState = {
 
 type DropdownProps = {
   icon?: {},
-  label: ?React.Node,
+  label?: React.Node,
   children: React.Node,
   menuVisible?: boolean,
   controlAction?: boolean,


### PR DESCRIPTION
Currently the label prop in the Dropdown component is a Maybe type, which means if we do not want to display a label, the prop still needs to be passed to avoid a Flow error. This PR seeks to make this prop optional to avoid an unnecessary prop-pass.