### PR TITLE
Front end/layout improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History: cultureamp-style-guide
 
+## 12.1.0
+
+* ✨ Add `Layout.Toasts` and `Layout.Announcers`. These regions are used with `aria-live="assertive"` so their contents will be read by a screen reader whenever the contents are changed. These are included in the high-level layout component as some screen readers need these regions to exist on the initial render.
+* 👍 Allow `<Text tag="label">`.
+* 👍 Add automationId props for MenuItem and Dropdown.
+* 👍 Add a chevron to all control-action styled dropdowns.
+* 👍 Use Book font-weight for control-actions (was previously using Medium).
+* 🐛 Ensure MenuItem links do not have underline on hover. This bug only existed when legacy global styles, such as Bootstrap, were used.
+
 ## 12.0.5
 
 * 🐛 Remove unnecessary flex rule that triggered bug with dropdown in IE11.

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -17,6 +17,7 @@ type DropdownProps = {
   children: React.Node,
   menuVisible?: boolean,
   controlAction?: boolean,
+  automationId?: string,
 };
 
 export default class Dropdown extends React.Component<
@@ -64,7 +65,7 @@ export default class Dropdown extends React.Component<
   }
 
   render() {
-    let { icon, label, controlAction } = this.props;
+    let { icon, label, controlAction, automationId } = this.props;
     if (!icon && !label) {
       icon = defaultIcon;
     }
@@ -79,6 +80,7 @@ export default class Dropdown extends React.Component<
           onClick={this.toggleDropdownMenu}
           onMouseDown={e => e.preventDefault()}
           ref={k => (this.dropdownButton = k)}
+          data-automation-id={automationId}
         >
           {icon && (
             <span className={styles.dropdownIcon}>

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import styles from './Dropdown.module.scss';
 import Icon from '../Icon/Icon';
 import defaultIcon from '../../icons/ellipsis.svg';
+import chevronDown from '../../icons/chevron-down.svg';
 import DropdownMenu from './DropdownMenu';
 
 type DropdownState = {
@@ -88,6 +89,12 @@ export default class Dropdown extends React.Component<
             </span>
           )}
           {label && <span className={styles.dropdownLabel}>{label}</span>}
+          {label &&
+            controlAction && (
+              <span className={styles.chevronIcon}>
+                <Icon icon={chevronDown} role="img" title="Open menu" />
+              </span>
+            )}
         </button>
         {this.state.isMenuVisible && this.renderDropdownMenu()}
       </div>

--- a/components/Dropdown/Dropdown.module.scss
+++ b/components/Dropdown/Dropdown.module.scss
@@ -68,6 +68,11 @@ $width: 248px;
   }
 }
 
+.chevronIcon {
+  position: relative;
+  top: 4px;
+}
+
 .menuContainer {
   position: absolute;
   width: $width;

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -13,12 +13,16 @@ class Layout extends React.Component<LayoutProps> {
     const header = extractChildOfType(content, Header);
     const sidebar = extractChildOfType(content, Sidebar);
     const footer = extractChildOfType(content, Footer);
+    const announcers = extractChildOfType(content, Announcers);
+    const toasts = extractChildOfType(content, Toasts);
 
     return (
       <div className={styles.root}>
         {navbar}
+        {announcers}
         <div className={styles.page}>
           {header}
+          {toasts}
           <div className={styles.body}>
             {sidebar}
             <main className={styles.content}>{content}</main>
@@ -33,6 +37,8 @@ class Layout extends React.Component<LayoutProps> {
   static Sidebar = Sidebar;
   static Header = Header;
   static Footer = Footer;
+  static Toasts = Toasts;
+  static Announcers = Announcers;
 }
 
 function NavigationBar(props: { children: React.Node }) {
@@ -49,6 +55,33 @@ function Header(props: { children: React.Node }) {
 
 function Footer(props: { children: React.Node }) {
   return <footer className={styles.footer}>{props.children}</footer>;
+}
+
+/**
+ * An area for toast notifications that will also trigger a screen-reader announcement.
+ * Content is absolutely positioned in the top right, but it is up to you to add appropriately styled notifications.
+ * By setting the children of `<Layout.Toasts>` the screen reader will immediately read its contents, without losing focus.
+ * You can safely add and remove toasts without worrying about the screen reader announcement being interrupted or repeated.
+ */
+function Toasts(props: { children: React.Node }) {
+  return (
+    <div className={styles.toasts} aria-live="assertive">
+      {props.children}
+    </div>
+  );
+}
+
+/**
+ * Announcements intended for screen readers only. Content will be invisible for sighted users.
+ * By setting the children of `<Layout.Announcers>` the screen reader will immediately read its contents, without losing focus.
+ * You can safely override the contents when adding a new announcement rather than appending the contents.
+ */
+function Announcers(props: { children: React.Node }) {
+  return (
+    <div className={styles.announcers} aria-live="assertive">
+      {props.children}
+    </div>
+  );
 }
 
 function extractChildOfType(children, type) {

--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -40,3 +40,16 @@
   @extend %footer;
   box-sizing: border-box;
 }
+
+.toasts {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.announcers {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0.5;
+}

--- a/components/MenuList/Menu.module.scss
+++ b/components/MenuList/Menu.module.scss
@@ -46,6 +46,7 @@ $side-padding: 3/4 * $ca-grid;
   &:focus {
     background: $ca-palette-stone;
     color: $ca-palette-ocean;
+    text-decoration: none;
 
     .menuItem__Icon {
       color: $ca-palette-ocean;

--- a/components/MenuList/Menu.module.scss
+++ b/components/MenuList/Menu.module.scss
@@ -46,6 +46,7 @@ $side-padding: 3/4 * $ca-grid;
   &:focus {
     background: $ca-palette-stone;
     color: $ca-palette-ocean;
+    // override Murmur global styles :(
     text-decoration: none;
 
     .menuItem__Icon {

--- a/components/MenuList/MenuItem.js
+++ b/components/MenuList/MenuItem.js
@@ -12,8 +12,17 @@ const MenuItem = (props: {
   destructive?: boolean,
   children: React.Node,
   action: string | ((e: Event) => void),
+  automationId?: string,
 }) => {
-  const { icon, hoverIcon, children, action, active, destructive } = props;
+  const {
+    icon,
+    hoverIcon,
+    children,
+    action,
+    active,
+    destructive,
+    automationId,
+  } = props;
   const isLink = typeof action === 'string',
     label = (
       <span className={styles.menuItem__Label}>
@@ -35,7 +44,12 @@ const MenuItem = (props: {
       [styles['menuItem--destructive']]: destructive,
     });
   return (
-    <a href={href} onClick={handleOnClick} className={className}>
+    <a
+      href={href}
+      onClick={handleOnClick}
+      className={className}
+      data-automation-id={automationId}
+    >
       {label}
       {iconNode}
     </a>

--- a/components/NavigationBar/components/Menu.module.scss
+++ b/components/NavigationBar/components/Menu.module.scss
@@ -16,7 +16,8 @@
   font: inherit;
   margin: 0;
   padding: 0;
-  transition: none; // override _bootstrap-overrides.scss
+  // override Murmur global styles :(
+  transition: none;
 
   // fill parent
   display: block;

--- a/components/Text/Text.js
+++ b/components/Text/Text.js
@@ -40,7 +40,6 @@ const Text = (props: TextProps) => {
   const style = props.style || defaultStyles[Tag];
   return (
     <Tag
-      {...props}
       className={classNames(styles[style], {
         [styles.inheritBaseline]: props.inheritBaseline,
         [styles.paragraph]: Tag === 'p',

--- a/components/Text/Text.js
+++ b/components/Text/Text.js
@@ -4,7 +4,7 @@ import styles from './Text.module.scss';
 import classNames from 'classnames';
 
 type TextProps = {
-  tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div',
+  tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div' | 'label',
   style?:
     | 'page-title'
     | 'title'
@@ -32,6 +32,7 @@ const defaultStyles = {
   h6: 'heading',
   p: 'body',
   div: 'body',
+  label: 'body',
 };
 
 const Text = (props: TextProps) => {
@@ -39,6 +40,7 @@ const Text = (props: TextProps) => {
   const style = props.style || defaultStyles[Tag];
   return (
     <Tag
+      {...props}
       className={classNames(styles[style], {
         [styles.inheritBaseline]: props.inheritBaseline,
         [styles.paragraph]: Tag === 'p',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "12.0.5",
+  "version": "12.1.0",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -191,7 +191,7 @@ $ca-ideal-sans-font-descender-height: 0.14;
 }
 
 @mixin ca-type-ideal-control-action($args...) {
-  @include ca-type-ideal($size: 16, $weight: $ca-weight-medium, $args...);
+  @include ca-type-ideal($size: 16, $weight: $ca-weight-book, $args...);
   text-decoration: none;
   text-decoration-skip-ink: auto;
   color: $ca-palette-ocean;


### PR DESCRIPTION
- Add Toasts and Announcers to Layout. Because of the needs of screen-readers to have any `aria-live` regions available on page start-up, I think it justifies these living inside the layout.
- Allow `<Text tag="label">`
- Add automationId props for MenuItem and Dropdown
- Add a chevron to control-action styled dropdowns
- Make control-actions book, not medium
- Fix for underline on MenuItem hover