### PR TITLE
12.2.0: Peer sass-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History: cultureamp-style-guide
 
-## 12.1.1
+## 12.2.0
 
 * 🐛 Add `sass-loader` as a `peerDependency` to help avoid multiple versions of this loader running in a single webpack build, which has been the source of intermittent hangs.
+* 👍 Re-upgrade `node-sass` to version 4.9.0 or compatible to match Murmur now that the source of webpack timeouts has been found.
 
 ## 12.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: cultureamp-style-guide
 
+## 12.1.1
+
+* 🐛 Add `sass-loader` as a `peerDependency` to help avoid multiple versions of this loader running in a single webpack build, which has been the source of intermittent hangs.
+
 ## 12.1.0
 
 * ✨ Add `Layout.Toasts` and `Layout.Announcers`. These regions are used with `aria-live="assertive"` so their contents will be read by a screen reader whenever the contents are changed. These are included in the high-level layout component as some screen readers need these regions to exist on the initial render.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css-loader": "^0.28.5",
     "elm-css-modules-loader": "^2.0.0",
     "elm-webpack-loader": "^4.3.1",
-    "node-sass": "4.7.2",
+    "node-sass": "^4.9.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.6.1",
     "react-html-id": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cultureamp-style-guide",
-  "version": "12.1.1",
+  "version": "12.2.0",
   "description": "Culture Amp Living Style Guide",
   "main": "index.js",
   "repository": "git@github.com:cultureamp/cultureamp-style-guide.git",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "extract-text-webpack-plugin": "^2.1.2 || ^3.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "sass-loader": "^6.0.6",
     "webpack": "^2.6.1 || ^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,7 +3535,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
 
-nan@^2.3.0, nan@^2.3.2:
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
@@ -3639,9 +3643,9 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.2.tgz#9366778ba1469eb01438a9e8592f4262bcb6794e"
+node-sass@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -3655,7 +3659,7 @@ node-sass@4.7.2:
     lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.3.2"
+    nan "^2.10.0"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
     request "~2.79.0"


### PR DESCRIPTION
We have experienced intermittent hangs in the final stages of webpack compilation when two versions of sass-loader are present in the build. By making `sass-loader` a `peerDependency`, we hope to ensure that the consuming project will specify a compatible version range, enabling Yarn/NPM to select a single version of `sass-loader`.