### PR TITLE
fix(button): Fix flow type errors in React Button component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-<PROJECT_ROOT>/guide/.*
 .*node_modules/fbjs/.*
 .*node_modules/find-elm-dependencies/.*
 .*node_modules/relay-compiler/.*

--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -5,21 +5,21 @@ import styles from './Button.module.scss';
 import Icon from '../Icon/Icon.js';
 
 type Props = {|
-  label: String,
+  label: string,
   icon?: {
-    id: String,
-    viewBox: String,
+    id: string,
+    viewBox: string,
   },
   iconPosition: IconPosition,
-  primary: Boolean,
-  destructive: Boolean,
-  disabled: Boolean,
-  form: Boolean,
-  reversed: Boolean,
+  primary: boolean,
+  destructive: boolean,
+  disabled: boolean,
+  form: boolean,
+  reversed: boolean,
   reverseColor?: 'lapis' | 'ocean' | 'peach' | 'seedling' | 'wisteria' | 'yuzu',
   onClick?: MouseEvent => void,
-  href?: String,
-  automationId?: String,
+  href?: string,
+  automationId?: string,
 |};
 
 type IconPosition = 'start' | 'end';

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -1,3 +1,4 @@
+// @flow
 import configureIcon from 'cultureamp-style-guide/icons/configure.svg';
 import Button from 'cultureamp-style-guide/components/Button/Button.js';
 import React from 'react';

--- a/guide/src/pages/components/Icon/_iconPresets.js
+++ b/guide/src/pages/components/Icon/_iconPresets.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Icon from 'cultureamp-style-guide/components/Icon';
 import configureIcon from 'cultureamp-style-guide/icons/configure.svg';

--- a/guide/src/pages/components/dropdown/_presets.js
+++ b/guide/src/pages/components/dropdown/_presets.js
@@ -1,3 +1,4 @@
+// @flow
 import Dropdown from 'cultureamp-style-guide/components/Dropdown';
 import {
   MenuList,

--- a/guide/src/pages/components/layout/_presets.js
+++ b/guide/src/pages/components/layout/_presets.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import Layout from 'cultureamp-style-guide/components/Layout';
 import NavigationBar from 'cultureamp-style-guide/components/NavigationBar';
@@ -25,7 +26,6 @@ const navBar = (
       />
       <NavigationBar.Menu
         tooltip="Culture Amp"
-        header={null}
         items={[
           {
             label: 'About Culture Amp',

--- a/guide/src/pages/components/menulist/_presets.js
+++ b/guide/src/pages/components/menulist/_presets.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   MenuList,
   MenuHeader,

--- a/guide/src/pages/components/navigationbar/_presets.js
+++ b/guide/src/pages/components/navigationbar/_presets.js
@@ -1,3 +1,4 @@
+// @flow
 import NavigationBar from 'cultureamp-style-guide/components/NavigationBar';
 import Icon from 'cultureamp-style-guide/components/Icon';
 import homeIcon from 'cultureamp-style-guide/icons/home.svg';
@@ -20,7 +21,6 @@ const supportLink = (
 const menu = (
   <NavigationBar.Menu
     tooltip="Culture Amp"
-    header={null}
     items={[
       {
         label: 'About Culture Amp',

--- a/guide/src/pages/components/text/_presets.js
+++ b/guide/src/pages/components/text/_presets.js
@@ -1,3 +1,4 @@
+// @flow
 import Text from 'cultureamp-style-guide/components/Text';
 import React from 'react';
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cz-conventional-changelog": "^2.1.0",
     "empty": "^0.10.1",
     "extract-text-webpack-plugin": "^3.0.0",
-    "flow-bin": "^0.69.0",
+    "flow-bin": "^0.76.0",
     "gh-pages": "^1.0.0",
     "postcss-normalize": "^3.0.0",
     "react": "^16.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3217,9 +3217,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.69.0:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
+flow-bin@^0.76.0:
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.76.0.tgz#eb00036991c3abc106743fcbc7ee321f02aa4faa"
 
 focus-visible@^4.1.4:
   version "4.1.4"


### PR DESCRIPTION
Previously it was using `String` rather than `string` and
`Boolean` rather than `boolean` which made it unusable.

We've also updated our style-guide flow config to type check
all the presets in our guide now to catch errors like this in
future.