### PR TITLE
Front end/react notification fixups

### DIFF
--- a/components/Notification/GlobalNotification.js
+++ b/components/Notification/GlobalNotification.js
@@ -7,6 +7,7 @@ type Props = {|
   type: NotificationType,
   children: React.Node,
   onHide?: () => void,
+  automationId?: string,
 |};
 
 const GlobalNotification = (props: Props) => (

--- a/components/Notification/InlineNotification.js
+++ b/components/Notification/InlineNotification.js
@@ -9,6 +9,7 @@ type Props = {|
   children: React.Node,
   persistent: boolean,
   onHide?: () => void,
+  automationId?: string,
 |};
 
 const InlineNotification = (props: Props) => (

--- a/components/Notification/ToastNotification.js
+++ b/components/Notification/ToastNotification.js
@@ -10,6 +10,7 @@ type Props = {|
   autohide: boolean,
   hideCloseIcon: boolean,
   onHide?: () => void,
+  automationId?: string,
 |};
 
 const ToastNotification = ({ hideCloseIcon, ...otherProps }: Props) => {

--- a/components/Notification/__tests__/InlineNotification.test.js
+++ b/components/Notification/__tests__/InlineNotification.test.js
@@ -4,7 +4,7 @@ import InlineNotification from '../InlineNotification';
 
 test('The basic notification renders correctly', () => {
   const notification = mount(
-    <InlineNotification type="warning" title="Warning">
+    <InlineNotification type="cautionary" title="Warning">
       Something has gone wrong
     </InlineNotification>
   );

--- a/components/Notification/__tests__/__snapshots__/InlineNotification.test.js.snap
+++ b/components/Notification/__tests__/__snapshots__/InlineNotification.test.js.snap
@@ -66,17 +66,17 @@ exports[`The basic notification renders correctly 1`] = `
 <InlineNotification
   persistent={false}
   title="Warning"
-  type="warning"
+  type="cautionary"
 >
   <GenericNotification
     autohide={false}
     persistent={false}
     style="inline"
     title="Warning"
-    type="warning"
+    type="cautionary"
   >
     <div
-      className="notification warning inline hidden"
+      className="notification cautionary inline hidden"
       onTransitionEnd={[Function]}
       style={
         Object {

--- a/components/Notification/_styles.scss
+++ b/components/Notification/_styles.scss
@@ -82,7 +82,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
     }
   }
 
-  &%ca-notification---warning {
+  &%ca-notification---cautionary {
     background: add-tint($ca-palette-yuzu, 95%);
     border-color: add-tint($ca-palette-yuzu, 60%);
     color: $ca-palette-lapis;
@@ -132,7 +132,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
     color: add-tint($ca-palette-ocean, 30%);
   }
 
-  %ca-notification---warning & {
+  %ca-notification---cautionary & {
     color: add-tint($ca-palette-yuzu, 20%);
   }
 

--- a/components/Notification/components/GenericNotification.js
+++ b/components/Notification/components/GenericNotification.js
@@ -22,6 +22,7 @@ type Props = {|
   persistent: boolean,
   autohide: boolean,
   onHide?: () => void,
+  automationId?: string,
 |};
 
 type State = {
@@ -54,6 +55,7 @@ class GenericNotification extends React.Component<Props, State> {
         style={{ marginTop: this.marginTop() }}
         ref={div => (this.container = div)}
         onTransitionEnd={e => this.onTransitionEnd(e)}
+        data-automation-id={this.props.automationId}
       >
         <div className={styles.icon}>
           <Icon icon={this.iconType()} role="presentation" inheritSize />

--- a/components/Notification/components/GenericNotification.js
+++ b/components/Notification/components/GenericNotification.js
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 export type NotificationType =
   | 'affirmative'
   | 'informative'
-  | 'warning'
+  | 'cautionary'
   | 'negative';
 
 type Props = {|
@@ -106,7 +106,7 @@ class GenericNotification extends React.Component<Props, State> {
         return successIcon;
       case 'negative':
         return exclamationIcon;
-      case 'warning':
+      case 'cautionary':
         return exclamationIcon;
       case 'informative':
         return infoIcon;

--- a/components/Notification/components/GenericNotification.module.scss
+++ b/components/Notification/components/GenericNotification.module.scss
@@ -60,8 +60,8 @@
   @extend %ca-notification---informative;
 }
 
-.warning {
-  @extend %ca-notification---warning;
+.cautionary {
+  @extend %ca-notification---cautionary;
 }
 
 .negative {

--- a/guide/gatsby-node.js
+++ b/guide/gatsby-node.js
@@ -89,6 +89,7 @@ function addElmLoader(config) {
     exclude: [/elm-stuff/, /node_modules/],
     loaders: [
       'elm-css-modules-loader',
+      'cultureamp-style-guide/webpack/elmSvgAssetLoader',
       'elm-webpack-loader?' + JSON.stringify({ debug: true }),
     ],
   });

--- a/guide/src/html.js
+++ b/guide/src/html.js
@@ -27,7 +27,7 @@ module.exports = class HTML extends React.Component {
           <link
             rel="stylesheet"
             type="text/css"
-            href="https://d1vmr11cgrgrrj.cloudfront.net/7095992/css/fonts.css"
+            href="https://d1vmr11cgrgrrj.cloudfront.net/7834392/css/fonts.css"
           />
           <link
             rel="stylesheet"

--- a/guide/src/pages/components/notification/_globalPresets.js
+++ b/guide/src/pages/components/notification/_globalPresets.js
@@ -25,9 +25,9 @@ const presets = [
     ),
   },
   {
-    name: 'Warning',
+    name: 'Cautionary',
     node: (
-      <GlobalNotification type="warning">
+      <GlobalNotification type="cautionary">
         New user data, imported by mackenzie@hooli.com has uploaded with some
         minor issues. <a href="/">View issues</a>
       </GlobalNotification>
@@ -54,7 +54,7 @@ const presets = [
           New user data is currently being processed. We'll let you know when
           the process is completed. <a href="/">Manage users</a>
         </GlobalNotification>
-        <GlobalNotification type="warning">
+        <GlobalNotification type="cautionary">
           New user data, imported by mackenzie@hooli.com has uploaded with some
           minor issues. <a href="/">View issues</a>
         </GlobalNotification>

--- a/guide/src/pages/components/notification/_inlinePresets.js
+++ b/guide/src/pages/components/notification/_inlinePresets.js
@@ -25,9 +25,9 @@ const presets = [
     ),
   },
   {
-    name: 'Warning',
+    name: 'Cautionary',
     node: (
-      <InlineNotification type="warning" title="Warning">
+      <InlineNotification type="cautionary" title="Warning">
         New user data, imported by mackenzie@hooli.com has uploaded with some
         minor issues. <a href="/">View issues</a>
       </InlineNotification>
@@ -61,9 +61,9 @@ const presets = [
     ),
   },
   {
-    name: 'Persistent, Warning',
+    name: 'Persistent, Cautionary',
     node: (
-      <InlineNotification type="warning" title="Warning" persistent>
+      <InlineNotification type="cautionary" title="Warning" persistent>
         New user data, imported by mackenzie@hooli.com has uploaded with some
         minor issues. <a href="/">View issues</a>
       </InlineNotification>
@@ -134,7 +134,7 @@ const presets = [
           New user data is currently being processed. We'll let you know when
           the process is completed. <a href="/">Manage users</a>
         </InlineNotification>
-        <InlineNotification type="warning" title="Warning">
+        <InlineNotification type="cautionary" title="Warning">
           New user data, imported by mackenzie@hooli.com has uploaded with some
           minor issues. <a href="/">View issues</a>
         </InlineNotification>

--- a/guide/src/pages/components/notification/_toastPresets.js
+++ b/guide/src/pages/components/notification/_toastPresets.js
@@ -48,9 +48,9 @@ const presets = [
     ),
   },
   {
-    name: 'Warning',
+    name: 'Cautionary',
     node: (
-      <ToastNotification type="warning" title="Warning">
+      <ToastNotification type="cautionary" title="Warning">
         New user data, imported by mackenzie@hooli.com has uploaded with some
         minor issues. <a href="/">View issues</a>
       </ToastNotification>
@@ -77,7 +77,7 @@ const presets = [
           New user data is currently being processed. We'll let you know when
           the process is completed. <a href="/">Manage users</a>
         </ToastNotification>
-        <ToastNotification type="warning" title="Warning">
+        <ToastNotification type="cautionary" title="Warning">
           New user data, imported by mackenzie@hooli.com has uploaded with some
           minor issues. <a href="/">View issues</a>
         </ToastNotification>


### PR DESCRIPTION
- Rename "warning" to "cautionary" in line with Sketch files (breaking change)
- Add "automationId" for all notification types
- Add elm svg icon loader to gatsby config
- Update ideal sans bundle