### PR TITLE
New reverse interaction states

### DIFF
--- a/components/Icon/Icon.module.scss
+++ b/components/Icon/Icon.module.scss
@@ -38,3 +38,18 @@
     }
   }
 }
+
+// On dark backgrounds, icons are fully opaque by default and half opacity when active.
+// Hover and disabled states are the same.
+.reversedInteractiveIconWrapper {
+  composes: interactiveIconWrapper;
+  .icon {
+    opacity: 1;
+  }
+  &:active,
+  &.active {
+    .icon {
+      opacity: 0.5;
+    }
+  }
+}

--- a/components/Icon/Icon.module.scss
+++ b/components/Icon/Icon.module.scss
@@ -24,17 +24,19 @@
       opacity: 0.3;
     }
   }
-  &:hover,
-  &:focus,
-  &.hover {
-    .icon {
-      opacity: 0.7;
+  &:not(:disabled, .disabled) {
+    &:hover,
+    &:focus,
+    &.hover {
+      .icon {
+        opacity: 0.7;
+      }
     }
-  }
-  &:active,
-  &.active {
-    .icon {
-      opacity: 1;
+    &:active,
+    &.active {
+      .icon {
+        opacity: 1;
+      }
     }
   }
 }
@@ -46,10 +48,12 @@
   .icon {
     opacity: 1;
   }
-  &:active,
-  &.active {
-    .icon {
-      opacity: 0.5;
+  &:not(:disabled, .disabled) {
+    &:active,
+    &.active {
+      .icon {
+        opacity: 0.5;
+      }
     }
   }
 }

--- a/guide/src/pages/components/Icon/index.md
+++ b/guide/src/pages/components/Icon/index.md
@@ -4,6 +4,7 @@ imports:
   Elm: ./Demo.elm
   IntroParagraph: components/IntroParagraph.js
   iconPresets: ./_iconPresets.js
+  Link: components/Link.js
 ---
 
 # Icon
@@ -17,3 +18,19 @@ Available for both Elm and React.
 </IntroParagraph>
 
 <Demo presets={iconPresets} elm={Elm.Icon.Demo} />
+
+### Interaction States
+
+To signify an icon's <Link to="/styles/icons#interaction-states">Interaction States</Link> we use varying levels of opacity.
+
+We have a helper class you can compose to utilize these styles:
+
+```
+.myButton {
+  composes: interactiveIconWrapper from 'cultureamp-style-guide/components/Icon/Icon.module.scss';
+}
+
+.myReversedButton {
+  composes: reversedInteractiveIconWrapper from 'cultureamp-style-guide/components/Icon/Icon.module.scss';
+}
+```

--- a/guide/src/pages/styles/icons/_InteractionStates.js
+++ b/guide/src/pages/styles/icons/_InteractionStates.js
@@ -12,23 +12,37 @@ class InteractionStates extends React.Component {
     return (
       <Card dark={this.props.dark}>
         <div className={styles.cardWrapper}>
-          {this.renderIcon('Disabled', iconStyles.disabled, 30)}
-          {this.renderIcon('Inactive', null, 50)}
-          {this.renderIcon('Hover', iconStyles.hover, 70)}
-          {this.renderIcon('Active', iconStyles.active, 100)}
+          {this.renderIcon(
+            'Disabled',
+            iconStyles.disabled,
+            30,
+            this.props.dark
+          )}
+          {this.renderIcon(
+            'Inactive',
+            null,
+            this.props.dark ? 100 : 50,
+            this.props.dark
+          )}
+          {this.renderIcon('Hover', iconStyles.hover, 70, this.props.dark)}
+          {this.renderIcon(
+            'Active',
+            iconStyles.active,
+            this.props.dark ? 50 : 100,
+            this.props.dark
+          )}
         </div>
       </Card>
     );
   }
 
-  renderIcon(title, interactionStateClass, opacity) {
+  renderIcon(title, interactionStateClass, opacity, dark) {
     return (
       <div
-        className={classNames(
-          styles.iconExample,
-          iconStyles.interactiveIconWrapper,
-          interactionStateClass
-        )}
+        className={classNames(styles.iconExample, interactionStateClass, {
+          [iconStyles.reversedInteractiveIconWrapper]: dark,
+          [iconStyles.interactiveIconWrapper]: !dark,
+        })}
       >
         <strong>{title}</strong>
         <span>

--- a/guide/src/pages/styles/icons/index.md
+++ b/guide/src/pages/styles/icons/index.md
@@ -5,6 +5,7 @@ imports:
   InteractionStates: ./_InteractionStates.js
   IconSizeSpaceTouch: ./_IconSizeSpaceTouch.js
   "{TipContainer,TipCard}": components/tip-card
+  Link: components/Link.js
 ---
 
 # Icons
@@ -12,6 +13,8 @@ imports:
 <IntroParagraph>
 
 Icons are a helpful and familiar visual aid to guide and inform users. Not just for aesthetics, they provide humanity by defining hierarchy for information and shaping a page’s composition, helping to make our product more approachable and usable.
+
+See our <Link to="/components/Icon">Icon Component</Link> for information about how to use these components.
 
 </IntroParagraph>
 
@@ -50,18 +53,18 @@ Icons are a helpful and familiar visual aid to guide and inform users. Not just 
 <TipContainer>
 <TipCard title="Icons should…" type="tip">
 
-- by default, by 20px in size (minimum) and can be scaled to larger sizes if it contextually makes sense.
+* by default, by 20px in size (minimum) and can be scaled to larger sizes if it contextually makes sense.
 
-- have a minimum touch zone of 48px
+* have a minimum touch zone of 48px
 
-- be accompanied by a label to support the visual. Try avoid using icons in isolation of labels, unless they are being used for a clear visual convention (e.g. Search, Home, Close, etc.)
+* be accompanied by a label to support the visual. Try avoid using icons in isolation of labels, unless they are being used for a clear visual convention (e.g. Search, Home, Close, etc.)
 
 </TipCard>
 <TipCard title="Icons should not…" type="warning">
 
-- be overused. Avoid using icons for the sake of it.
+* be overused. Avoid using icons for the sake of it.
 
-- need to align to the baseline grid.
+* need to align to the baseline grid.
 
 </TipCard>
 </TipContainer>


### PR DESCRIPTION
Fixes a bug where interactiveIconWrapper still used active/hover states even if disabled.

And adds a new reversedInteractiveIconWrapper class, which is different, and document the differences.