### PR TITLE
Fix broken interactive icon highlight styles

### DIFF
--- a/components/Icon/Icon.module.scss
+++ b/components/Icon/Icon.module.scss
@@ -24,7 +24,7 @@
       opacity: 0.3;
     }
   }
-  &:not(:disabled, .disabled) {
+  &:not(:disabled):not(.disabled) {
     &:hover,
     &:focus,
     &.hover {


### PR DESCRIPTION
`:not(a, b)` syntax is not supported by current browsers, and is not transpiled by our CSS postprocessor (apparently).