### PR TITLE
Automatic text for Elm component availability

### DIFF
--- a/guide/src/components/Demo.js
+++ b/guide/src/components/Demo.js
@@ -32,8 +32,15 @@ export default class Demo extends React.Component {
   render() {
     return (
       <div className={styles.root}>
+        <p className={styles.p}>
+          { this.props.elm ?
+              "Available for both Elm and React." :
+              "Currently available for React." }
+        </p>
+
         {this.renderPresetList()}
         {this.renderCanvas()}
+
         <div className={styles.controls}>{this.renderSizePresets()}</div>
         <div className={styles.controls}>
           {this.renderOptions()}

--- a/guide/src/components/Demo.module.scss
+++ b/guide/src/components/Demo.module.scss
@@ -37,7 +37,7 @@
 .selectPreset {
   position: absolute;
   right: 0;
-  bottom: calc(100% + 1em);
+  top: 0;
   select {
     @include ca-type-ideal-body;
   }
@@ -61,4 +61,9 @@
 
 .renderOptions > *:not(:first-child) {
   margin-left: $ca-grid;
+}
+
+.p {
+  margin: $ca-grid 0;
+  @include ca-type-ideal-body;
 }

--- a/guide/src/pages/components/Button/button.md
+++ b/guide/src/pages/components/Button/button.md
@@ -12,8 +12,6 @@ imports:
 
 A button!
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={buttonPresets} elm={Elm.Button.ButtonDemo} />

--- a/guide/src/pages/components/Button/icon-button.md
+++ b/guide/src/pages/components/Button/icon-button.md
@@ -12,8 +12,6 @@ imports:
 
 A button with an icon but no label.
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={buttonPresets} elm={Elm.Button.IconButtonDemo} />

--- a/guide/src/pages/components/Icon/index.md
+++ b/guide/src/pages/components/Icon/index.md
@@ -13,8 +13,6 @@ imports:
 
 An icon! To control its color, set color on a parent element, and it will be inherited.
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={iconPresets} elm={Elm.Icon.Demo} />

--- a/guide/src/pages/components/layout/index.md
+++ b/guide/src/pages/components/layout/index.md
@@ -11,8 +11,6 @@ imports:
 
 A standard Culture Amp layout with left-hand-side navigation bar, sidebar, and optional headers / footers.
 
-Currently available for React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />

--- a/guide/src/pages/components/menulist/index.md
+++ b/guide/src/pages/components/menulist/index.md
@@ -11,8 +11,6 @@ imports:
 
 A generic list of items or actions, to be used with dropdown menus etc.
 
-Currently available for React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />

--- a/guide/src/pages/components/navigationbar/index.md
+++ b/guide/src/pages/components/navigationbar/index.md
@@ -11,8 +11,6 @@ imports:
 
 The standard left-hand-side navigation bar used by Culture Amp applications.
 
-Currently available for React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />

--- a/guide/src/pages/components/notification/global.md
+++ b/guide/src/pages/components/notification/global.md
@@ -11,8 +11,6 @@ imports:
 
 A global notification!
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />

--- a/guide/src/pages/components/notification/inline.md
+++ b/guide/src/pages/components/notification/inline.md
@@ -11,8 +11,6 @@ imports:
 
 An inline notification!
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />

--- a/guide/src/pages/components/notification/toast.md
+++ b/guide/src/pages/components/notification/toast.md
@@ -11,8 +11,6 @@ imports:
 
 A toast notification!
 
-Available for both Elm and React.
-
 </IntroParagraph>
 
 <Demo presets={presets} />


### PR DESCRIPTION
* Removed Elm component availability text from markdown. 
* Use 'elm' prop on `Demo` react component to determine if an Elm component is available instead.

<img width="1043" alt="screen shot 2018-08-14 at 8 04 20 pm" src="https://user-images.githubusercontent.com/723683/44085571-52e8dc4c-9ffd-11e8-8f75-5e5b292e4ced.png">

<img width="1046" alt="screen shot 2018-08-14 at 8 04 34 pm" src="https://user-images.githubusercontent.com/723683/44085573-54831ee6-9ffd-11e8-8177-c7beeb9fc0b8.png">
