### PR TITLE
fix(button): Upgrade focus-visible polyfill to fix IE11 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "css-loader": "^0.28.11",
     "elm-css-modules-loader": "^2.1.5",
     "elm-webpack-loader": "^4.5.0",
-    "focus-visible": "^4.1.4",
+    "focus-visible": "^4.1.5",
     "node-sass": "^4.9.0",
     "postcss-loader": "^2.1.5",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,9 +3662,9 @@ flow-bin@^0.76.0:
   version "0.76.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.76.0.tgz#eb00036991c3abc106743fcbc7ee321f02aa4faa"
 
-focus-visible@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.4.tgz#f9963bcf5784b1d9dcde62ba53214d38a4f3f9af"
+focus-visible@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.5.tgz#50b44e2e84c24b831ceca3cce84d57c2b311c855"
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
We had a string of errors with this polyfill when using inline SVGs in our pages (as we do for
icons). The updated version of the library contains a fix for this.