### PR TITLE
add ability to add type=submit|reset attribute to Button.elm

### DIFF
--- a/components/Button/Button.elm
+++ b/components/Button/Button.elm
@@ -68,11 +68,25 @@ view (Config config) label =
         onClick =
             case config.onClick of
                 Just msg ->
-                    [ onWithOptions
-                        "click"
-                        { defaultOptions | preventDefault = True }
-                        (Json.succeed msg)
-                    ]
+                    let
+                        preventDefault =
+                            case config.buttonType of
+                                Just buttonType ->
+                                    case buttonType of
+                                        Submit ->
+                                            False
+
+                                        Reset ->
+                                            False
+
+                                Nothing ->
+                                    True
+                    in
+                        [ onWithOptions
+                            "click"
+                            { defaultOptions | preventDefault = preventDefault }
+                            (Json.succeed msg)
+                        ]
 
                 Nothing ->
                     []

--- a/components/Button/Button.elm
+++ b/components/Button/Button.elm
@@ -65,32 +65,6 @@ view (Config config) label =
                 ]
             ]
 
-        onClick =
-            case config.onClick of
-                Just msg ->
-                    let
-                        preventDefault =
-                            case config.buttonType of
-                                Just buttonType ->
-                                    case buttonType of
-                                        Submit ->
-                                            False
-
-                                        Reset ->
-                                            False
-
-                                Nothing ->
-                                    True
-                    in
-                        [ onWithOptions
-                            "click"
-                            { defaultOptions | preventDefault = preventDefault }
-                            (Json.succeed msg)
-                        ]
-
-                Nothing ->
-                    []
-
         automationId =
             case config.automationId of
                 Just id ->
@@ -107,7 +81,60 @@ view (Config config) label =
             else
                 []
 
-        buttonTypeAttrib =
+        attribs =
+            buttonClass
+                ++ onClickAttribs (Config config)
+                ++ automationId
+                ++ title
+                ++ buttonTypeAttribs (Config config)
+    in
+        span [ class .container ]
+            [ case config.href of
+                Just href ->
+                    a (attribs ++ [ Html.Attributes.href href ])
+                        [ viewContent (Config config) label |> Html.map never ]
+
+                Nothing ->
+                    button (attribs ++ disabled)
+                        [ viewContent (Config config) label |> Html.map never ]
+            ]
+
+
+onClickAttribs : Config msg -> List (Html.Attribute msg)
+onClickAttribs (Config config) =
+    case config.onClick of
+        Just msg ->
+            let
+                preventDefault =
+                    case config.buttonType of
+                        Just buttonType ->
+                            case buttonType of
+                                Submit ->
+                                    False
+
+                                Reset ->
+                                    False
+
+                        Nothing ->
+                            True
+            in
+                [ onWithOptions
+                    "click"
+                    { defaultOptions | preventDefault = preventDefault }
+                    (Json.succeed msg)
+                ]
+
+        Nothing ->
+            []
+
+
+buttonTypeAttribs : Config msg -> List (Html.Attribute msg)
+buttonTypeAttribs (Config config) =
+    case config.href of
+        Just _ ->
+            []
+
+        Nothing ->
             case config.buttonType of
                 Just buttonType ->
                     let
@@ -123,20 +150,6 @@ view (Config config) label =
 
                 Nothing ->
                     []
-
-        attribs =
-            buttonClass ++ onClick ++ automationId ++ title ++ buttonTypeAttrib
-    in
-        span [ class .container ]
-            [ case config.href of
-                Just href ->
-                    a (attribs ++ [ Html.Attributes.href href ])
-                        [ viewContent (Config config) label |> Html.map never ]
-
-                Nothing ->
-                    button (attribs ++ disabled)
-                        [ viewContent (Config config) label |> Html.map never ]
-            ]
 
 
 viewContent : Config msg -> String -> Html Never

--- a/components/Button/Button.elm
+++ b/components/Button/Button.elm
@@ -19,6 +19,8 @@ module Button.Button
         , href
         , automationId
         , Config
+        , buttonType
+        , ButtonType(..)
         )
 
 import Html exposing (Html, text, span, button, a)
@@ -91,8 +93,25 @@ view (Config config) label =
             else
                 []
 
+        buttonTypeAttrib =
+            case config.buttonType of
+                Just buttonType ->
+                    let
+                        encodedButtonType =
+                            case buttonType of
+                                Submit ->
+                                    "submit"
+
+                                Reset ->
+                                    "reset"
+                    in
+                        [ Html.Attributes.type_ encodedButtonType ]
+
+                Nothing ->
+                    []
+
         attribs =
-            buttonClass ++ onClick ++ automationId ++ title
+            buttonClass ++ onClick ++ automationId ++ title ++ buttonTypeAttrib
     in
         span [ class .container ]
             [ case config.href of
@@ -179,6 +198,7 @@ type alias ConfigValue msg =
     , onClick : Maybe msg
     , href : Maybe String
     , automationId : Maybe String
+    , buttonType : Maybe ButtonType
     }
 
 
@@ -221,6 +241,7 @@ defaults =
     , onClick = Nothing
     , href = Nothing
     , automationId = Nothing
+    , buttonType = Nothing
     }
 
 
@@ -296,3 +317,13 @@ href value (Config config) =
 automationId : String -> Config msg -> Config msg
 automationId value (Config config) =
     Config { config | automationId = Just value }
+
+
+type ButtonType
+    = Submit
+    | Reset
+
+
+buttonType : ButtonType -> Config msg -> Config msg
+buttonType value (Config config) =
+    Config { config | buttonType = Just value }


### PR DESCRIPTION
This PR competes with https://github.com/cultureamp/cultureamp-style-guide/compare/mab/button-extra-attributes. Please pick one! (or none)

This requirement came about as we are embedding a small form component inside a legacy backend driven form.

**Pros to this approach over letting users add arbitrary attributes**:
- Dissuades people from using using antipatterns such as `target=_blank`
- The Elm compiler can stop users from giving incorrect attributes/values such as `type=sbmit`

**Cons**
See https://github.com/cultureamp/cultureamp-style-guide/compare/mab/button-extra-attributes.
