### PR TITLE
enforce text transform to avoid bootstrap global style

### DIFF
--- a/components/Notification/_styles.scss
+++ b/components/Notification/_styles.scss
@@ -185,6 +185,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
   @include ca-type-ideal-heading;
   margin: 0;
   padding-right: $ca-grid / 2;
+  text-transform: none;
 }
 
 %ca-notification__text {


### PR DESCRIPTION
Fixing the title
![integrations](https://user-images.githubusercontent.com/995875/45010331-3a7ddf00-b050-11e8-93d4-9ff358e13756.png)
