### PR TITLE
Add ability to add type=submit|reset to React Button

### DIFF
--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -14,6 +14,7 @@ type GenericProps = {|
   icon?: SvgAsset,
   onClick?: MouseEvent => void,
   href?: string,
+  type?: 'submit' | 'reset',
   automationId?: string,
 |};
 
@@ -54,7 +55,7 @@ export default function GenericButton(props: Props) {
 }
 
 function renderButton(props: Props) {
-  const { disabled, onClick } = props;
+  const { disabled, onClick, type } = props;
   const label = props.icon && props.iconButton ? props.label : undefined;
 
   return (
@@ -67,6 +68,7 @@ function renderButton(props: Props) {
           onClick && onClick(e);
         }
       }}
+      type={type}
       data-automation-id={props.automationId}
       title={label}
       aria-label={label}

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -92,6 +92,14 @@ const buttonPresets = [
     node: <Button label="Label" primary reversed disabled />,
     darkBackground: true,
   },
+  {
+    name: 'Type Submit',
+    node: <Button label="Label" type="submit" />,
+  },
+  {
+    name: 'Type Reset',
+    node: <Button label="Label" type="reset" />,
+  },
 ];
 
 export default buttonPresets;


### PR DESCRIPTION
This adds the ability to add a `type` prop to the React Button component, similar to what was done for the Elm Button in #121.

Technically a button's type can be `'submit'`, `'reset'` or `'button'` but for consistency with the Elm API I've kept the React one as `'submit' | 'reset'` as well. If this is a problem let me know.