### PR TITLE
No longer use travis-deploy-once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ script:
 - yarn flow
 - yarn jest
 - bin/buildSite
-after_success:
-- yarn global add travis-deploy-once
-- travis-deploy-once "yarn semantic-release"
+- yarn semantic-release
 deploy:
   provider: pages
   local-dir: guide/public


### PR DESCRIPTION
Semantic-release is smart enough to know not to deploy if we're not on master.
Now builds will fail if semantic-release fails.