### PR TITLE
Opens in a new tab tooltip on menu items that have target=_blank

### DIFF
--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -2,10 +2,12 @@
 import * as React from 'react';
 
 import styles from './Menu.module.scss';
+import Tooltip from './Tooltip.js';
 
 type MenuItem = {
   label: string,
   link: string,
+  target: '_self' | '_blank' | '_parent' | '_top',
   data?: { [key: string]: string },
 };
 
@@ -67,8 +69,32 @@ export default class Menu extends React.Component<Props, State> {
     );
   }
 
-  renderMenuItem(item: MenuItem, index: number) {
-    const { label, link, data = {} } = item;
+  renderMenuItem = (item: MenuItem, index: number) => {
+    const { target } = item;
+
+    if (target === '_blank') {
+      return (
+        <Tooltip
+          hideTooltip={false}
+          tabIndex={null} // link inside takes focus instead
+          tooltip="Opens in a new window"
+          key={index}
+          setDisplayBlock={true}
+        >
+          {this.renderMenuItemLink(item)}
+        </Tooltip>
+      );
+    }
+
+    return (
+      <React.Fragment key={index}>
+        {this.renderMenuItemLink(item)}
+      </React.Fragment>
+    );
+  };
+
+  renderMenuItemLink = item => {
+    const { label, link, target, data = {} } = item;
 
     const dataAttributes = {};
     Object.keys(data).forEach(key => {
@@ -77,15 +103,15 @@ export default class Menu extends React.Component<Props, State> {
 
     return (
       <a
-        key={index}
         href={link}
         className={styles.menuItem}
+        target={target}
         {...dataAttributes}
       >
         {label}
       </a>
     );
-  }
+  };
 
   componentDidMount() {
     document.addEventListener('click', this.clickDocument);

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -77,7 +77,7 @@ export default class Menu extends React.Component<Props, State> {
         <Tooltip
           hideTooltip={false}
           tabIndex={null} // link inside takes focus instead
-          tooltip="Opens in a new window"
+          tooltip="Opens in a new tab"
           key={index}
           setDisplayBlock={true}
         >

--- a/components/GlobalIANavigationBar/components/Tooltip.js
+++ b/components/GlobalIANavigationBar/components/Tooltip.js
@@ -1,0 +1,52 @@
+// @flow
+import * as React from 'react';
+import classNames from 'classnames';
+
+import styles from './Tooltip.module.scss';
+
+type Props = {|
+  children?: React.Node,
+  tabIndex: number | null,
+  tooltip: string,
+  hideTooltip: boolean,
+  onMenuChange?: (open: boolean) => void,
+  setDisplayBlock?: boolean,
+|};
+
+const Tooltip = ({
+  children,
+  tabIndex,
+  tooltip,
+  hideTooltip,
+  setDisplayBlock,
+}: Props) => {
+  return (
+    <div
+      className={classNames(styles.root, {
+        [styles.setDisplayBlock]: setDisplayBlock,
+      })}
+      tabIndex={tabIndex}
+    >
+      {children}
+      <div
+        className={classNames(styles.tooltip, {
+          [styles.suppressed]: hideTooltip,
+        })}
+        aria-hidden // tooltips are hidden from screen readers! Use aria-label/aria-labelled-by on children
+      >
+        <div>
+          <small className={styles.content}>{tooltip}</small>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Tooltip.displayName = 'Tooltip';
+
+Tooltip.defaultProps = {
+  hideTooltip: false,
+  tabIndex: 0,
+};
+
+export default Tooltip;

--- a/components/GlobalIANavigationBar/components/Tooltip.module.scss
+++ b/components/GlobalIANavigationBar/components/Tooltip.module.scss
@@ -1,0 +1,69 @@
+@import '~cultureamp-style-guide/styles/border';
+@import '~cultureamp-style-guide/styles/color';
+@import '~cultureamp-style-guide/styles/type';
+
+.root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  // contain child margins
+  display: inline-block;
+
+  &:focus {
+    // non-interactive focus, so no focus outline
+    outline: 0;
+  }
+}
+
+.setDisplayBlock {
+  display: block;
+}
+
+.tooltip {
+  $tooltip__arrow-size: $ca-grid * 0.25;
+
+  display: flex;
+  align-items: center;
+
+  position: absolute;
+  height: 100%;
+  top: 0;
+
+  right: -1000em;
+  &:not(.suppressed) {
+    :hover > &,
+    :focus > &,
+    :focus + &,
+    &.visible {
+      right: calc(100% + #{$ca-grid - $tooltip__arrow-size});
+    }
+  }
+
+  // tooltip arrow
+  &::before {
+    content: '';
+    position: absolute;
+    right: -$tooltip__arrow-size;
+    top: calc(50% - #{$tooltip__arrow-size});
+
+    border: $tooltip__arrow-size solid transparent;
+    border-right-width: 0;
+    border-left-color: $ca-palette-ink;
+  }
+
+  > * {
+    color: #fff;
+    background-color: $ca-palette-ink;
+    border-radius: $ca-border-radius;
+    padding: $ca-border-radius 0;
+    white-space: nowrap;
+  }
+}
+
+.content {
+  @include ca-type-ideal-small;
+  @include ca-inherit-baseline;
+  margin: 0 1em;
+  position: static;
+}

--- a/components/NavigationBar/components/Menu.js
+++ b/components/NavigationBar/components/Menu.js
@@ -7,6 +7,7 @@ import Tooltip from './Tooltip.js';
 type MenuItem = {
   label: string,
   link: string,
+  target: '_self' | '_blank' | '_parent' | '_top',
   data?: { [key: string]: string },
 };
 
@@ -80,8 +81,32 @@ export default class Menu extends React.Component<Props, State> {
     );
   }
 
-  renderMenuItem(item: MenuItem, index: number) {
-    const { label, link, data = {} } = item;
+  renderMenuItem = (item: MenuItem, index: number) => {
+    const { target } = item;
+
+    if (target === '_blank') {
+      return (
+        <Tooltip
+          hideTooltip={false}
+          tabIndex={null} // link inside takes focus instead
+          tooltip="Opens in a new tab"
+          key={index}
+          setDisplayBlock={true}
+        >
+          {this.renderMenuItemLink(item)}
+        </Tooltip>
+      );
+    }
+
+    return (
+      <React.Fragment key={index}>
+        {this.renderMenuItemLink(item)}
+      </React.Fragment>
+    );
+  };
+
+  renderMenuItemLink = item => {
+    const { label, link, target, data = {} } = item;
 
     const dataAttributes = {};
     Object.keys(data).forEach(key => {
@@ -90,15 +115,15 @@ export default class Menu extends React.Component<Props, State> {
 
     return (
       <a
-        key={index}
         href={link}
         className={styles.menuItem}
+        target={target}
         {...dataAttributes}
       >
         {label}
       </a>
     );
-  }
+  };
 
   componentDidMount() {
     document.addEventListener('click', this.clickDocument);

--- a/components/NavigationBar/components/Tooltip.js
+++ b/components/NavigationBar/components/Tooltip.js
@@ -10,11 +10,23 @@ type Props = {|
   tooltip: string,
   hideTooltip: boolean,
   onMenuChange?: (open: boolean) => void,
+  setDisplayBlock?: boolean,
 |};
 
-const Tooltip = ({ children, tabIndex, tooltip, hideTooltip }: Props) => {
+const Tooltip = ({
+  children,
+  tabIndex,
+  tooltip,
+  hideTooltip,
+  setDisplayBlock,
+}: Props) => {
   return (
-    <div className={styles.root} tabIndex={tabIndex}>
+    <div
+      className={classNames(styles.root, {
+        [styles.setDisplayBlock]: setDisplayBlock,
+      })}
+      tabIndex={tabIndex}
+    >
       {children}
       <div
         className={classNames(styles.tooltip, {

--- a/components/NavigationBar/components/Tooltip.module.scss
+++ b/components/NavigationBar/components/Tooltip.module.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.setDisplayBlock {
+  display: block;
+}
+
 .tooltip {
   $tooltip__arrow-size: $ca-grid * 0.25;
 


### PR DESCRIPTION
This PR adds a tooltip with "**Opens in a new tab**" on links that have a **_blank** target.

- I've rolled this across the current nav bar whilst we transition across to the new layout. 
- The new global navbar has the same implimentation, though there are some small changes to make it appear to the left of the menu.

