### PR TITLE
fix(webpack): No longer include focus-visible polyfill by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ module.exports = decorateWithStyleGuide(webpackConfig, {
 });
 ```
 
+You will also need to add `focus-visible` to your build - by requiring it in your JavaScript or adding it to your webpack entrypoints.
+
 ### Importing React Components
 
 React components may be imported from the cultureamp-style-guide module, and

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -10,7 +10,6 @@ function decorateConfig(config, options) {
     decorateRules,
     addStyleGuideRules,
     addStyleGuideAlias,
-    addStyleGuideDependencies,
   ].reduce((decoratedConfig, decorator) => {
     return decorator(decoratedConfig, options);
   }, config);
@@ -228,19 +227,4 @@ function styleGuidePaths() {
   ];
 
   return module._styleGuidePaths;
-}
-
-function addStyleGuideDependencies(config) {
-  const dependencies = [require.resolve('focus-visible')];
-
-  const entry = {};
-  if (typeof config.entry === 'object') {
-    Object.entries(config.entry).forEach(([key, value]) => {
-      entry[key] = dependencies.concat(value);
-    });
-  } else {
-    config.entry = dependencies.concat(config.entry);
-  }
-
-  return Object.assign({}, config, { entry });
 }


### PR DESCRIPTION
The decorator added it to all entrypoints, including entrypoints which are other polyfills - which is not desirable. Now we have put the expectation back on the consuming project (murmur) to add the polyfill themselves.

If it's not present, the style-guide components still work but without the additional accessibility / keyboard focus styles.