### PR TITLE
Fix flex child overflowing in ie10

### DIFF
--- a/components/Notification/_styles.scss
+++ b/components/Notification/_styles.scss
@@ -199,6 +199,7 @@ $ca-notification-slide-right: transform $ca-duration-slow ease-out;
     // When the title and text are on different lines this ensures the baselines of the first lines are exactly 1 grid unit apart.
     // When they are both on a single line it ensures both are 1 grid unit tall.
     margin-top: $ca-grid / 4;
+    flex: 0 1 auto;
   }
 
   %ca-notification---global & {


### PR DESCRIPTION
In IE10 the default value for flex is `0 0 auto` rather than `0 1 auto` as defined in the latest spec.
Which means this happens:
![screen shot 2018-10-17 at 10 20 05 am](https://user-images.githubusercontent.com/7019081/47053215-ad55aa80-d1f7-11e8-95aa-9d5ea660cc0b.png)
