### PR TITLE
Load presets via source files

### DIFF
--- a/guide/src/components/Demo.js
+++ b/guide/src/components/Demo.js
@@ -1,4 +1,5 @@
-import React from 'react';
+// @flow
+import * as React from 'react';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 import Text from 'cultureamp-style-guide/components/Text';
 import Button from 'cultureamp-style-guide/components/Button';
@@ -8,15 +9,49 @@ import styles from './Demo.module.scss';
 
 const MIN_CANVAS_WIDTH = 240;
 
-const SMALL = Symbol('small');
-const MEDIUM = Symbol('medium');
-const LARGE = Symbol('large');
-const RANDOM = Symbol('random');
-const FULL = Symbol('full');
-const REACT = Symbol('react');
-const ELM = Symbol('elm');
+type CanvasSize = 'small' | 'medium' | 'large' | 'random' | 'full';
+const SMALL = 'small';
+const MEDIUM = 'medium';
+const LARGE = 'large';
+const RANDOM = 'random';
+const FULL = 'full';
 
+type Platform = 'react' | 'elm';
+const REACT = 'react';
+const ELM = 'elm';
+
+type Preset = {
+  name: string,
+  node: React.Node,
+  darkBackground?: boolean,
+};
+
+type DemoProps = {
+  presets: Array<Preset>,
+  elm?: ElmApp,
+};
+
+type DemoState = {
+  selectedPreset: number,
+  assignedCanvasWidth: ?number,
+  actualCanvasDimensions: {
+    width: ?number,
+    height: ?number,
+  },
+  showGridOverlay: boolean,
+  darkBackground: boolean,
+  platform: 'react' | 'elm',
+};
+
+export default class Demo extends React.Component<DemoProps, DemoState> {
+  canvas: ?Element;
+  frame: ?Element;
+  resizing: boolean = false;
+
+<<<<<<< HEAD
 export default class Demo extends React.Component {
+=======
+>>>>>>> 7e4058a... Update Elm/React component loader to work with Elm 0.19
   state = {
     selectedPreset: 0,
     assignedCanvasWidth: null,
@@ -87,29 +122,34 @@ export default class Demo extends React.Component {
 
   renderComponent() {
     return {
-      [ELM]: presetComponent => (
-        <ElmWithRefreshingProps
-          src={this.props.elm}
-          flags={this.convertNodeToFlags(presetComponent)}
-          ports={this.elmPortsFromProps(presetComponent.props)}
-        />
-      ),
+      [ELM]: (presetComponent: React.Node) => {
+        const elmApp = this.props.elm;
+        if (!elmApp) {
+          return 'Failed to load elm demo';
+        }
+        return (
+          <ElmComponent
+            src={elmApp}
+            flags={this.convertNodeToFlags(presetComponent)}
+          />
+        );
+      },
       [REACT]: presetComponent => presetComponent,
     }[this.state.platform](this.selectedPreset().node);
   }
 
-  convertNodeToFlags(node) {
+  convertNodeToFlags(node: any): { type: any, props: {} } {
     if (!node || typeof node !== 'object') {
       return node;
     }
 
     return {
-      props: this.convertPropsToFlags(node.props),
       type: node.type.displayName || node.type,
+      props: this.convertPropsToFlags(node.props),
     };
   }
 
-  convertPropsToFlags(props) {
+  convertPropsToFlags(props: {}) {
     return Object.keys(props).reduce((flags, key) => {
       let value = props[key];
 
@@ -129,8 +169,8 @@ export default class Demo extends React.Component {
     }, {});
   }
 
-  elmPortsFromProps(props) {
-    return (ports = {}) => {
+  elmPortsFromProps(props: {}) {
+    return (ports: {} = {}) => {
       const listeners = Object.keys(props).reduce(
         (listeners, key) =>
           typeof props[key] === 'function'
@@ -146,7 +186,7 @@ export default class Demo extends React.Component {
     };
   }
 
-  selectedPreset() {
+  selectedPreset(): Preset {
     return this.props.presets[this.state.selectedPreset];
   }
 
@@ -212,6 +252,7 @@ export default class Demo extends React.Component {
   }
 
   renderReactCode() {
+    // $FlowFixMe: reactElementToJSXString can take a React.Node, not just a React.Element
     let jsxCode = reactElementToJSXString(this.selectedPreset().node, {
       showDefaultProps: false,
       sortProps: false,
@@ -238,22 +279,22 @@ export default class Demo extends React.Component {
     window.removeEventListener('resize', this.onResize);
   }
 
-  onChangeGridOverlay = e => {
+  onChangeGridOverlay = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const showGridOverlay = e.target.checked;
     this.setState({ showGridOverlay });
   };
 
-  onChangeDarkBackground = e => {
+  onChangeDarkBackground = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const darkBackground = e.target.checked;
     this.setState({ darkBackground });
   };
 
-  onChangeElm = e => {
+  onChangeElm = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const elm = e.target.checked;
     this.setState({ platform: elm ? ELM : REACT });
   };
 
-  onSelectPreset = e => {
+  onSelectPreset = (e: SyntheticInputEvent<HTMLSelectElement>) => {
     const selectedPreset = parseInt(e.target.value);
     this.setState({
       ...this.state,
@@ -263,11 +304,11 @@ export default class Demo extends React.Component {
     });
   };
 
-  onClickResizeTo(size) {
-    return e => this.resizeToSize(size);
+  onClickResizeTo(size: CanvasSize) {
+    return () => this.resizeToSize(size);
   }
 
-  resizeToSize(size) {
+  resizeToSize(size: CanvasSize) {
     switch (size) {
       case FULL:
         this.resizeTo();
@@ -287,7 +328,7 @@ export default class Demo extends React.Component {
     }
   }
 
-  resizeTo(assignedCanvasWidth = null) {
+  resizeTo(assignedCanvasWidth: ?number = null) {
     assignedCanvasWidth =
       assignedCanvasWidth &&
       Math.min(assignedCanvasWidth, this.maxCanvasWidth());
@@ -302,13 +343,13 @@ export default class Demo extends React.Component {
     });
   }
 
-  setAssignedCanvasWidth(assignedCanvasWidth) {
+  setAssignedCanvasWidth(assignedCanvasWidth: ?number) {
     this.setState({ ...this.state, assignedCanvasWidth });
     this.onResize();
   }
 
-  maxCanvasWidth() {
-    return this.frame.clientWidth;
+  maxCanvasWidth(): number {
+    return this.frame ? this.frame.clientWidth : 0;
   }
 
   onResize = () => {
@@ -321,6 +362,10 @@ export default class Demo extends React.Component {
   onResizeFrame = () => {
     if (this.isResizeComplete()) {
       this.resizing = false;
+      return;
+    }
+
+    if (!this.canvas) {
       return;
     }
 
@@ -337,6 +382,9 @@ export default class Demo extends React.Component {
   };
 
   isResizeComplete() {
+    if (!this.canvas) {
+      return false;
+    }
     const { clientWidth, clientHeight } = this.canvas;
     const {
       assignedCanvasWidth,
@@ -355,28 +403,41 @@ function randomBetween(min, max) {
   return Math.floor(Math.random() * (max - min) + min);
 }
 
-// We are not using react-elm-components because they do not update the Elm app when props change.
-class ElmWithRefreshingProps extends React.Component {
+// Note: we can't use elm-react-components because we need to update flags when presets change
+// (also it does not have an Elm 0.19 update)
+
+type ElmApp = {
+  init: ({ node: Element, flags?: {} }) => { ports: ({}) => void },
+};
+
+class ElmComponent extends React.Component<{ src: ElmApp, flags: {} }> {
   render() {
-    return <div ref={node => (this.node = node)} />;
+    return <div ref={node => this.initialize(node)} />;
   }
 
-  componentDidMount() {
-    this.mountElm();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (JSON.stringify(prevProps) !== JSON.stringify(this.props)) {
-      this.mountElm();
-    }
-  }
-
+<<<<<<< HEAD
   mountElm() {
     this.node.innerHTML = '';
     const app = this.props.src.embed(this.node, this.props.flags);
 
     if (typeof this.props.ports !== 'undefined') {
       this.props.ports(app.ports);
+=======
+  initialize(container) {
+    if (container != null) {
+      // Unlike react-elm-components, which makes `shouldComponentUpdate()` return false, we allow updating the component.
+      // For our style-guide demos, this means removing the existing Elm app from the DOM, and instantiating a new one.
+      container.innerHTML = '';
+      // Elm 0.19 doesn't place itself inside the container node, it *replaces* the container node.
+      // This can cause runtime errors if the container node - which React rendered - suddenly is removed by Elm, and React goes to update or remove it, only to find it is now gone.
+      // The workaround is to create an extra <div>, which React doesn't control, and allow Elm to replace that node.
+      const elmPlaceholder = document.createElement('div');
+      container.appendChild(elmPlaceholder);
+      const app = this.props.src.init({
+        node: elmPlaceholder,
+        flags: this.props.flags,
+      });
+>>>>>>> 7e4058a... Update Elm/React component loader to work with Elm 0.19
     }
   }
 }

--- a/guide/src/components/PresetDemo.js
+++ b/guide/src/components/PresetDemo.js
@@ -1,0 +1,118 @@
+// @flow
+import * as React from 'react';
+import Text from 'cultureamp-style-guide/components/Text';
+
+type Preset = {
+  react?: Class<React.Component<{}>>,
+  elm?: { Elm: any },
+};
+
+type Props = {
+  presets: { [name: string]: Preset },
+};
+
+type State = {
+  preset: ?string,
+  platform: 'react' | 'elm',
+};
+
+class PresetDemo extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      preset: Object.keys(props.presets)[0],
+      platform: 'react',
+    };
+  }
+
+  render() {
+    const { presets } = this.props;
+
+    return (
+      <div>
+        {this.renderPresetSelect()}
+        {this.renderPlatformSelect()}
+        {this.renderDemo(this.state.preset, this.state.platform)}
+      </div>
+    );
+  }
+
+  renderPresetSelect() {
+    return (
+      <select onChange={e => this.setState({ preset: e.target.value })}>
+        {Object.keys(this.props.presets).map(preset => (
+          <option value={preset} key={preset}>
+            {preset}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  renderPlatformSelect() {
+    if (!this.state.preset) {
+      return;
+    }
+    const preset = this.props.presets[this.state.preset];
+    return (
+      <select onChange={e => this.setState({ platform: e.target.value })}>
+        {Object.keys(preset).map(platform => (
+          <option value={platform} key={platform}>
+            {platform}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  renderDemo(presetName: ?string, platform: string) {
+    const preset = presetName && this.props.presets[presetName];
+    if (!presetName || !preset) {
+      return 'Preset not found';
+    }
+    if (platform === 'react') {
+      if (!preset.react) {
+        return 'No React version :(';
+      }
+      const ReactComponent: Class<React.Component<{}>> = preset.react;
+      return (
+        <div>
+          <Text tag="h2">{presetName}</Text>
+          <Text tag="h3">React</Text>
+          <ReactComponent />
+        </div>
+      );
+    }
+    if (platform === 'elm') {
+      if (!preset.elm) {
+        return 'No elm version :(';
+      }
+      return (
+        <article>
+          <Text tag="h2">{presetName}</Text>
+          <Text tag="h3">Elm</Text>
+          <ElmComponent src={preset.elm} />
+        </article>
+      );
+    }
+  }
+}
+
+class ElmComponent extends React.Component<{ src: any }> {
+  render() {
+    return <section ref={node => this.initialize(node)} />;
+  }
+
+  initialize(node) {
+    if (node != null) {
+      console.log('What is node', node);
+      node.innerHTML = '';
+      console.log('Attempting to mount');
+      const app = this.props.src.init({
+        node: node,
+      });
+    }
+  }
+}
+
+export default PresetDemo;

--- a/guide/src/pages/components/Button/Presets/Default.elm
+++ b/guide/src/pages/components/Button/Presets/Default.elm
@@ -1,0 +1,33 @@
+module Default exposing (main)
+
+import Browser
+import Button.Button as Button exposing (..)
+import Html exposing (Html, div, text)
+import Text.Text as Text exposing (p)
+
+
+main =
+    Browser.sandbox { init = 0, update = update, view = view }
+
+
+type alias Model =
+    Int
+
+
+type Msg
+    = Increment
+
+
+update : Msg -> Model -> Model
+update Increment model =
+    model + 1
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ Button.view
+            (Button.default |> Button.onClick Increment)
+            "Label"
+        , Text.view p [ text ("Clicked " ++ String.fromInt model ++ " times") ]
+        ]

--- a/guide/src/pages/components/Button/Presets/Default.js
+++ b/guide/src/pages/components/Button/Presets/Default.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react';
+import Button from 'cultureamp-style-guide/components/Button';
+import Text from 'cultureamp-style-guide/components/Text';
+
+class DefaultButtonDemo extends React.Component<{}, { count: number }> {
+  state = { count: 0 };
+  render() {
+    return (
+      <div>
+        <Text tag="p">Clicked {this.state.count} times</Text>
+      </div>
+    );
+  }
+
+  increment() {
+    this.setState({
+      count: this.state.count + 1,
+    });
+  }
+}
+
+export default DefaultButtonDemo;

--- a/guide/src/pages/components/Button/Presets/index.js
+++ b/guide/src/pages/components/Button/Presets/index.js
@@ -1,0 +1,12 @@
+const presets = {
+  default: {
+    react: require('./Default.js'),
+    elm: require('./Default.elm').Elm.Default,
+  },
+  secondary: {
+    react: require('./Default.js'),
+    elm: require('./Default.elm').Elm.Default,
+  },
+};
+
+export default presets;

--- a/guide/src/pages/components/Button/button.md
+++ b/guide/src/pages/components/Button/button.md
@@ -1,9 +1,11 @@
 ---
 imports:
   Demo: components/Demo.js
+  PresetDemo: components/PresetDemo.js
   Elm: ./ButtonDemo.elm
   IntroParagraph: components/IntroParagraph.js
   buttonPresets: ./_buttonPresets.js
+  buttonPresets2: ./Presets
 ---
 
 # Button
@@ -13,5 +15,7 @@ imports:
 A button!
 
 </IntroParagraph>
+
+<PresetDemo presets={buttonPresets2} />
 
 <Demo presets={buttonPresets} elm={Elm.Button.ButtonDemo} />


### PR DESCRIPTION
This is an attempt to use stand-alone, compileable files for our presets.

This will mean we can write our presets for React in React, and Elm in Elm, rather than the weird props conversion thing we're doing currently. 

This will

- allow better iteration while designing Elm component APIs (you have to try the Elm API in order to demo the preset!)
- be self documenting - we now have exact source code for each example which we'll be able to print
- open up the door to make an "edit preset in Code Sandbox" link in future

(this is very much a work in progress that I'm hoping to come back to later)