### PR TITLE
Add reversed variant on our reusable dropdown component

### DIFF
--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -20,6 +20,7 @@ type DropdownProps = {
   menuVisible?: boolean,
   controlAction?: boolean,
   automationId?: string,
+  reversed?: boolean,
 };
 
 export default class Dropdown extends React.Component<
@@ -68,13 +69,14 @@ export default class Dropdown extends React.Component<
   }
 
   render() {
-    let { icon, label, controlAction, automationId } = this.props;
+    let { icon, label, controlAction, automationId, reversed } = this.props;
     if (!icon && !label) {
       icon = defaultIcon;
     }
     const btnClass = classNames(styles.dropdownButton, {
       [styles.dropdownControlAction]: controlAction,
       [styles.isOpen]: this.state.isMenuVisible,
+      [styles.reversed]: reversed,
     });
     return (
       <div className={styles.dropdown}>

--- a/components/Dropdown/Dropdown.module.scss
+++ b/components/Dropdown/Dropdown.module.scss
@@ -89,3 +89,7 @@ $width: 248px;
     left: 0;
   }
 }
+
+.reversed {
+  color: $white;
+}

--- a/guide/src/pages/components/Dropdown/_presets.js
+++ b/guide/src/pages/components/Dropdown/_presets.js
@@ -8,7 +8,8 @@ import {
 } from 'cultureamp-style-guide/components/MenuList';
 import meatballs from 'cultureamp-style-guide/icons/meatballs.svg';
 import kebab from 'cultureamp-style-guide/icons/kebab.svg';
-import print from 'cultureamp-style-guide/icons/print-white.svg';
+import printWhite from 'cultureamp-style-guide/icons/print-white.svg';
+import print from 'cultureamp-style-guide/icons/print.svg';
 import enso from 'cultureamp-style-guide/icons/ca-monogram.svg';
 import React from 'react';
 
@@ -61,10 +62,19 @@ const presets = [
   {
     name: 'Control action',
     node: (
-      <Dropdown label="Print" icon={print} controlAction={true}>
+      <Dropdown label="Print" icon={printWhite} controlAction={true}>
         {menuList}
       </Dropdown>
     ),
+  },
+  {
+    name: 'Reversed Control action',
+    node: (
+      <Dropdown label="Print" icon={print} controlAction={true} reversed>
+        {menuList}
+      </Dropdown>
+    ),
+    darkBackground: true,
   },
 ];
 


### PR DESCRIPTION
This PR is about adding reversed variant on our `Dropdown` re-usable component so therefore we can use this component to do:

![screen shot 2018-11-01 at 11 25 48 am](https://user-images.githubusercontent.com/1903131/47831488-dcb60b00-dde4-11e8-8f6f-84bb92b07c5e.png)
