### PR TITLE
Add prettier to the style-guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
     "postcss-normalize": "^3.0.0",
+    "prettier": "^1.14.3",
     "raw-loader": "^0.5.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9487,6 +9487,11 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+
 pretty-format@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"


### PR DESCRIPTION
I never realised it was missing! We even have prettierrc and prettierignore files, but not the actual library.

Thanks @ellisjas for pointing it out