### PR TITLE
set type=button on generic notification dismiss button

### DIFF
--- a/components/Notification/Notification.elm
+++ b/components/Notification/Notification.elm
@@ -274,7 +274,7 @@ viewCancelButton (Config { persistent, variant }) state onStateChange =
 
     else
         button
-            ([ styles.class .cancel ]
+            ([ styles.class .cancel, type_ "button" ]
                 ++ onClickCancel
             )
             [ span

--- a/components/Notification/Notification.elm
+++ b/components/Notification/Notification.elm
@@ -22,7 +22,7 @@ import Elm19Compatible.Browser.Events exposing (onAnimationFrame)
 import Elm19Compatible.Html.Attributes
 import Elm19Compatible.String exposing (fromInt)
 import Html exposing (Html, button, div, h6, p, span, text)
-import Html.Attributes
+import Html.Attributes exposing (type_)
 import Html.Events as Events exposing (on)
 import Icon.Icon as Icon
 import Icon.SvgAsset exposing (svgAsset)

--- a/components/Notification/__tests__/__snapshots__/GlobalNotification.test.js.snap
+++ b/components/Notification/__tests__/__snapshots__/GlobalNotification.test.js.snap
@@ -55,6 +55,7 @@ exports[`The basic notification renders correctly 1`] = `
         <button
           className="cancel"
           onClick={[Function]}
+          type="button"
         >
           <span
             className="cancelInner"
@@ -149,6 +150,7 @@ exports[`You can change the type 1`] = `
         <button
           className="cancel"
           onClick={[Function]}
+          type="button"
         >
           <span
             className="cancelInner"

--- a/components/Notification/__tests__/__snapshots__/InlineNotification.test.js.snap
+++ b/components/Notification/__tests__/__snapshots__/InlineNotification.test.js.snap
@@ -125,6 +125,7 @@ exports[`The basic notification renders correctly 1`] = `
         <button
           className="cancel"
           onClick={[Function]}
+          type="button"
         >
           <span
             className="cancelInner"

--- a/components/Notification/__tests__/__snapshots__/ToastNotification.test.js.snap
+++ b/components/Notification/__tests__/__snapshots__/ToastNotification.test.js.snap
@@ -64,6 +64,7 @@ exports[`The basic notification renders correctly 1`] = `
         <button
           className="cancel"
           onClick={[Function]}
+          type="button"
         >
           <span
             className="cancelInner"
@@ -163,6 +164,7 @@ exports[`You cannot hide the close icon unless it is an autohide 1`] = `
         <button
           className="cancel"
           onClick={[Function]}
+          type="button"
         >
           <span
             className="cancelInner"

--- a/components/Notification/components/GenericNotification.js
+++ b/components/Notification/components/GenericNotification.js
@@ -124,7 +124,7 @@ class GenericNotification extends React.Component<Props, State> {
 }
 
 const CancelButton = ({ onClick }) => (
-  <button className={styles.cancel} onClick={onClick}>
+  <button className={styles.cancel} type="button" onClick={onClick}>
     <span className={styles.cancelInner}>
       <Icon icon={closeIcon} role="img" title="close notification" />
     </span>

--- a/components/Notification/components/__tests__/__snapshots__/GenericNotification.test.js.snap
+++ b/components/Notification/components/__tests__/__snapshots__/GenericNotification.test.js.snap
@@ -59,6 +59,7 @@ exports[`The cancel button hides the notification and triggers the onHide callba
       <button
         className="cancel"
         onClick={[Function]}
+        type="button"
       >
         <span
           className="cancelInner"
@@ -152,6 +153,7 @@ exports[`The cancel button hides the notification and triggers the onHide callba
       <button
         className="cancel"
         onClick={[Function]}
+        type="button"
       >
         <span
           className="cancelInner"


### PR DESCRIPTION
adds type="button"  on generic notification dismiss button. This prevents submitting forms by accident when dismissing notifications if the notification is inside a form tag