### PR TITLE
Updates and fixes for GlobalIALayout component

### DIFF
--- a/components/GlobalIALayout/Layout.js
+++ b/components/GlobalIALayout/Layout.js
@@ -24,8 +24,10 @@ class Layout extends React.Component<LayoutProps> {
           {header}
           {toasts}
           <div className={styles.body}>
-            {sidebar}
-            <main className={styles.content}>{content}</main>
+            <div className={styles.bodyInner}>
+              {sidebar}
+              <main className={styles.content}>{content}</main>
+            </div>
           </div>
           {footer}
         </div>
@@ -48,7 +50,11 @@ function NavigationBar(props: { children: React.Node }) {
 NavigationBar.displayName = 'NavigationBar';
 
 function Sidebar(props: { children: React.Node }) {
-  return <div className={styles.sidebar}>{props.children}</div>;
+  return (
+    <div className={styles.sidebar}>
+      <div className={styles.sidebarInner}>{props.children}</div>
+    </div>
+  );
 }
 Sidebar.displayName = 'Sidebar';
 

--- a/components/GlobalIALayout/Layout.js
+++ b/components/GlobalIALayout/Layout.js
@@ -92,7 +92,9 @@ function Announcers(props: { children: React.Node }) {
 Announcers.displayName = 'Announcers';
 
 function extractChildOfType(children, type) {
-  const match = children.find(child => child && child.type.name == type.name);
+  const match = children.find(
+    child => child && child.type.displayName == type.displayName
+  );
   if (match) {
     const index = children.indexOf(match);
     children.splice(index, 1);

--- a/components/GlobalIALayout/Layout.module.scss
+++ b/components/GlobalIALayout/Layout.module.scss
@@ -26,9 +26,17 @@
   box-sizing: border-box;
 }
 
+.bodyInner {
+  @extend %global-ia-body-inner;
+}
+
 .sidebar {
   @extend %global-ia-sidebar;
   box-sizing: border-box;
+}
+
+.sidebarInner {
+  @extend %global-ia-sidebar-inner;
 }
 
 .content {

--- a/components/GlobalIALayout/_styles.scss
+++ b/components/GlobalIALayout/_styles.scss
@@ -62,7 +62,7 @@
 // and support a sticky footer that conforms to those dimensions
 %global-ia-body-inner {
   display: flex;
-
+  align-self: center;
   max-width: $ca-layout-max-width;
 
   // match position & dimensions of %global-ia-body


### PR DESCRIPTION
Two fixes for the `GlobalIALayout` component.

# Layout not working when react-hot-loader is used

If hot reloading is in use, `type.name` on child elements get values of `ProxyFacade` so the clever function that extracts child components and slots them in the right place doesn't work. `type.displayName` is something we set explicitly and is not interfered with by hot reloading, so it should be safer and more reliable.

![screen shot 2018-11-15 at 12 05 08 pm](https://user-images.githubusercontent.com/4900094/48529332-a39e9000-e8e6-11e8-8a84-29b577066080.png)

# Incorrect layout

It looks like various CSS rules for the GlobalIALayout had been changed but the React component not updated to keep up.

This makes sure that the component uses the rules from `%global-ia-body-inner` and `%global-ia-sidebar-inner` which are required for elements to lay out properly.

Before:

![bad_layout](https://user-images.githubusercontent.com/4900094/48529586-df862500-e8e7-11e8-9a03-8bec2b02d580.png)

After:

![center_align](https://user-images.githubusercontent.com/4900094/48529495-71d9f900-e8e7-11e8-84f9-d95eacdc75ea.png)