### PR TITLE
OffCanvas navigation component

### DIFF
--- a/components/GlobalIANavigationBar/NavigationBar.js
+++ b/components/GlobalIANavigationBar/NavigationBar.js
@@ -11,7 +11,7 @@ import {
   LocalBadge,
   namedBadge,
 } from './components/Badge.js';
-import { TABLET_AND_UP } from './constants';
+import { MOBILE_QUERY } from './constants';
 import Link from './components/Link.js';
 import Menu from './components/Menu.js';
 import ControlledOffCanvas from '../OffCanvas';
@@ -47,9 +47,16 @@ export default class NavigationBar extends React.Component<Props> {
     });
 
     return (
-      <Media query={TABLET_AND_UP}>
+      <Media query={MOBILE_QUERY}>
         {matches =>
           matches ? (
+            <ControlledOffCanvas
+              headerComponent={this.renderBadge()}
+              footerComponent={this.props.footerComponent}
+              links={[...links, ...otherChildren]}
+              heading="Menu"
+            />
+          ) : (
             <header
               className={classNames(styles.navigationBar, styles[colorScheme])}
             >
@@ -57,13 +64,6 @@ export default class NavigationBar extends React.Component<Props> {
               {this.renderLinks(links)}
               {this.renderOtherChildren(otherChildren)}
             </header>
-          ) : (
-            <ControlledOffCanvas
-              headerComponent={this.renderBadge()}
-              footerComponent={this.props.footerComponent}
-              links={[...links, ...otherChildren]}
-              heading="Menu"
-            />
           )
         }
       </Media>

--- a/components/GlobalIANavigationBar/NavigationBar.js
+++ b/components/GlobalIANavigationBar/NavigationBar.js
@@ -22,6 +22,7 @@ type Props = {|
   loading: boolean,
   colorScheme: 'cultureamp' | 'kaizen',
   badgeHref: string,
+  footerComponent: ?React.Node,
   children: React.ChildrenArray<SupportedChild | false>,
 |};
 
@@ -58,6 +59,7 @@ export default class NavigationBar extends React.Component<Props> {
           ) : (
             <ControlledOffCanvas
               headerComponent={this.renderBadge()}
+              footerComponent={this.props.footerComponent}
               links={[...links, ...otherChildren]}
               heading="Menu"
             />

--- a/components/GlobalIANavigationBar/NavigationBar.js
+++ b/components/GlobalIANavigationBar/NavigationBar.js
@@ -13,7 +13,7 @@ import {
 } from './components/Badge.js';
 import Link from './components/Link.js';
 import Menu from './components/Menu.js';
-import OffCanvas from '../OffCanvas';
+import ControlledOffCanvas from '../OffCanvas';
 
 type SupportedChild = React.Element<typeof Link> | React.Element<typeof Menu>;
 
@@ -56,7 +56,11 @@ export default class NavigationBar extends React.Component<Props> {
               {this.renderOtherChildren(otherChildren)}
             </header>
           ) : (
-            <OffCanvas badgeComponent={this.renderBadge()} links={links} />
+            <ControlledOffCanvas
+              headerComponent={this.renderBadge()}
+              links={[...links, ...otherChildren]}
+              heading="Menu"
+            />
           )
         }
       </Media>

--- a/components/GlobalIANavigationBar/NavigationBar.js
+++ b/components/GlobalIANavigationBar/NavigationBar.js
@@ -11,6 +11,7 @@ import {
   LocalBadge,
   namedBadge,
 } from './components/Badge.js';
+import { TABLET_AND_UP } from './constants';
 import Link from './components/Link.js';
 import Menu from './components/Menu.js';
 import ControlledOffCanvas from '../OffCanvas';
@@ -46,7 +47,7 @@ export default class NavigationBar extends React.Component<Props> {
     });
 
     return (
-      <Media query="(min-width: 768px)">
+      <Media query={TABLET_AND_UP}>
         {matches =>
           matches ? (
             <header

--- a/components/GlobalIANavigationBar/NavigationBar.js
+++ b/components/GlobalIANavigationBar/NavigationBar.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
+import Media from 'react-media';
 
 import styles from './NavigationBar.module.scss';
 import {
@@ -12,6 +13,7 @@ import {
 } from './components/Badge.js';
 import Link from './components/Link.js';
 import Menu from './components/Menu.js';
+import OffCanvas from '../OffCanvas';
 
 type SupportedChild = React.Element<typeof Link> | React.Element<typeof Menu>;
 
@@ -43,11 +45,21 @@ export default class NavigationBar extends React.Component<Props> {
     });
 
     return (
-      <header className={classNames(styles.navigationBar, styles[colorScheme])}>
-        {this.renderBadge()}
-        {this.renderLinks(links)}
-        {this.renderOtherChildren(otherChildren)}
-      </header>
+      <Media query="(min-width: 768px)">
+        {matches =>
+          matches ? (
+            <header
+              className={classNames(styles.navigationBar, styles[colorScheme])}
+            >
+              {this.renderBadge()}
+              {this.renderLinks(links)}
+              {this.renderOtherChildren(otherChildren)}
+            </header>
+          ) : (
+            <OffCanvas badgeComponent={this.renderBadge()} links={links} />
+          )
+        }
+      </Media>
     );
   }
 

--- a/components/GlobalIANavigationBar/components/Link.js
+++ b/components/GlobalIANavigationBar/components/Link.js
@@ -6,6 +6,7 @@ import styles from './Link.module.scss';
 import Icon from '../../Icon';
 import type { SvgAsset } from '../../Icon/Icon.js';
 import Tooltip from './Tooltip.js';
+import chevronRightIcon from 'cultureamp-style-guide/icons/chevron-right.svg';
 
 type Props = {|
   icon?: SvgAsset,
@@ -18,6 +19,7 @@ type Props = {|
   onClick?: (event: SyntheticMouseEvent<>) => void,
   tooltipText?: string,
   target: '_self' | '_blank',
+  hasMenu?: boolean,
 |};
 
 export default class Link extends React.PureComponent<Props> {
@@ -39,6 +41,7 @@ export default class Link extends React.PureComponent<Props> {
       secondary,
       iconOnly,
       target,
+      hasMenu,
     } = this.props;
 
     return (
@@ -63,6 +66,11 @@ export default class Link extends React.PureComponent<Props> {
           !(icon && iconOnly) && (
             <span className={styles.linkText}>{text}</span>
           )}
+        {hasMenu && (
+          <span className={styles.menuIcon}>
+            <Icon icon={chevronRightIcon} role="presentation" />
+          </span>
+        )}
       </a>
     );
   };

--- a/components/GlobalIANavigationBar/components/Link.module.scss
+++ b/components/GlobalIANavigationBar/components/Link.module.scss
@@ -1,6 +1,7 @@
 @import '../styles';
 @import '~cultureamp-style-guide/styles/border';
 @import '~cultureamp-style-guide/styles/type';
+@import '~cultureamp-style-guide/styles/responsive';
 
 $nav-ease: cubic-bezier(0.55, 0.085, 0.68, 0.53);
 $nav-timing: 150ms;
@@ -38,6 +39,13 @@ $link-margin: $ca-grid / 4;
     right: 0;
     background-color: #fff;
     transition: transform $nav-ease $nav-timing;
+
+    @include ca-media-mobile {
+      width: $indicator-height;
+      height: 60px;
+      right: auto;
+      transform: translateX(-#{$link-margin}) translateX(-100%);
+    }
   }
 
   &:hover {
@@ -46,6 +54,10 @@ $link-margin: $ca-grid / 4;
 
     .linkText::before {
       transform: translateY(-#{$link-margin});
+
+      @include ca-media-mobile {
+        transform: translateX(-#{$link-margin});
+      }
     }
   }
 

--- a/components/GlobalIANavigationBar/components/Link.module.scss
+++ b/components/GlobalIANavigationBar/components/Link.module.scss
@@ -11,6 +11,11 @@ $link-margin: $ca-grid / 4;
 .link {
   @extend %ca-global-ia-navigation-bar__menu-item-focus;
 
+  @include ca-media-mobile {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
   // fill parent
   display: flex;
   min-width: 2 * $ca-grid;
@@ -66,34 +71,36 @@ $link-margin: $ca-grid / 4;
   top: 0;
 
   &.secondary {
-    @include ca-type-ideal-body;
-    @include ca-inherit-baseline;
+    @include ca-media-tablet-and-up {
+      @include ca-type-ideal-body;
+      @include ca-inherit-baseline;
 
-    padding: 0 $ca-grid / 2;
+      padding: 0 $ca-grid / 2;
 
-    .linkText {
-      padding: 0;
+      .linkText {
+        padding: 0;
 
-      &::before {
-        display: none;
+        &::before {
+          display: none;
+        }
       }
-    }
 
-    &:hover,
-    &:focus {
-      background-color: rgba(#fff, 0.1);
+      &:hover,
+      &:focus {
+        background-color: rgba(#fff, 0.1);
 
-      .linkIcon {
-        opacity: 0.7;
+        .linkIcon {
+          opacity: 0.7;
+        }
       }
-    }
 
-    &:active {
-      background-color: rgba(#fff, 0.2);
-      transform: translateY(1px);
+      &:active {
+        background-color: rgba(#fff, 0.2);
+        transform: translateY(1px);
 
-      .linkIcon {
-        opacity: 1;
+        .linkIcon {
+          opacity: 1;
+        }
       }
     }
   }
@@ -102,10 +109,18 @@ $link-margin: $ca-grid / 4;
 .linkIcon {
   display: inline-flex;
   opacity: 0.5;
+
+  @include ca-media-mobile {
+    display: none;
+  }
 }
 
 .linkIcon + .linkText {
   margin-left: $link-margin;
+
+  @include ca-media-mobile {
+    margin-left: 0;
+  }
 }
 
 .linkText {

--- a/components/GlobalIANavigationBar/components/Link.module.scss
+++ b/components/GlobalIANavigationBar/components/Link.module.scss
@@ -14,6 +14,7 @@ $link-margin: $ca-grid / 4;
   @include ca-media-mobile {
     width: 100%;
     justify-content: flex-start;
+    align-items: center;
   }
 
   // fill parent
@@ -144,4 +145,12 @@ $link-margin: $ca-grid / 4;
   .linkText::before {
     transform: translateY(-#{$link-margin});
   }
+}
+
+.menuIcon {
+  margin-left: auto;
+  margin-right: $ca-grid;
+  opacity: 0.5;
+  display: flex;
+  align-items: center;
 }

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import styles from './Menu.module.scss';
 import Tooltip from './Tooltip';
 import Link from './Link';
-import { TABLET_AND_UP } from '../constants';
+import { MOBILE_QUERY } from '../constants';
 import Media from 'react-media';
 import { OffCanvas } from '../../OffCanvas';
 import IconButton from '../../Button/IconButton';
@@ -43,9 +43,19 @@ export default class Menu extends React.Component<Props, State> {
     const { children, automationId, heading } = this.props;
 
     return (
-      <Media query={TABLET_AND_UP}>
+      <Media query={MOBILE_QUERY}>
         {matches =>
           matches ? (
+            <React.Fragment>
+              <Link
+                text={heading ? heading : 'Menu'}
+                href="#"
+                onClick={this.toggle}
+                hasMenu
+              />
+              {this.renderOffCanvas(this.state.open)}
+            </React.Fragment>
+          ) : (
             <nav className={styles.root} ref={root => (this.root = root)}>
               <button
                 className={styles.button}
@@ -58,16 +68,6 @@ export default class Menu extends React.Component<Props, State> {
               </button>
               {this.state.open && this.renderMenu()}
             </nav>
-          ) : (
-            <React.Fragment>
-              <Link
-                text={heading ? heading : 'Menu'}
-                href="#"
-                onClick={this.toggle}
-                hasMenu
-              />
-              {this.renderOffCanvas(this.state.open)}
-            </React.Fragment>
           )
         }
       </Media>

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -6,8 +6,8 @@ import Tooltip from './Tooltip';
 import Link from './Link';
 import { TABLET_AND_UP } from '../constants';
 import Media from 'react-media';
-import { OffCanvas } from 'cultureamp-style-guide/components/OffCanvas';
-import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import { OffCanvas } from '../../OffCanvas';
+import IconButton from '../../Button/IconButton';
 import backIcon from 'cultureamp-style-guide/icons/arrow-backward.svg';
 
 type MenuItem = {

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -58,7 +58,7 @@ export default class Menu extends React.Component<Props, State> {
             </nav>
           ) : (
             <React.Fragment>
-              <Link text="Settings" onClick={this.toggle} hasMenu />
+              <Link text="Settings" href="#" onClick={this.toggle} hasMenu />
               {this.renderOffCanvas(this.state.open)}
             </React.Fragment>
           )
@@ -85,7 +85,7 @@ export default class Menu extends React.Component<Props, State> {
     );
   }
 
-  renderOffCanvas(isOpen) {
+  renderOffCanvas(isOpen: boolean) {
     const { items } = this.props;
 
     return (
@@ -100,10 +100,12 @@ export default class Menu extends React.Component<Props, State> {
   }
 
   renderBackButton() {
-    return <IconButton icon={backIcon} onClick={this.toggle} reversed />;
+    return (
+      <IconButton label="Back" icon={backIcon} onClick={this.toggle} reversed />
+    );
   }
 
-  renderOffCanvasMenuItem = (item: Menuitem, index: number) => {
+  renderOffCanvasMenuItem = (item: MenuItem, index: number) => {
     return <Link key={index} text={item.label} href={item.link} />;
   };
 

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -58,7 +58,7 @@ export default class Menu extends React.Component<Props, State> {
             </nav>
           ) : (
             <React.Fragment>
-              <Link text="Settings" onClick={this.toggle} />
+              <Link text="Settings" onClick={this.toggle} hasMenu />
               {this.renderOffCanvas(this.state.open)}
             </React.Fragment>
           )
@@ -94,6 +94,7 @@ export default class Menu extends React.Component<Props, State> {
         menuVisible={isOpen}
         heading="Settings"
         headerComponent={this.renderBackButton()}
+        toggleMenu={this.toggle}
       />
     );
   }

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import styles from './Menu.module.scss';
 import Tooltip from './Tooltip';
 import Link from './Link';
+import { TABLET_AND_UP } from '../constants';
 import Media from 'react-media';
 import { OffCanvas } from 'cultureamp-style-guide/components/OffCanvas';
 import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
@@ -42,7 +43,7 @@ export default class Menu extends React.Component<Props, State> {
     const { children, automationId, heading } = this.props;
 
     return (
-      <Media query="(min-width: 768px)">
+      <Media query={TABLET_AND_UP}>
         {matches =>
           matches ? (
             <nav className={styles.root} ref={root => (this.root = root)}>

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -21,6 +21,7 @@ type Props = {|
   header?: React.Element<any>,
   items: Array<MenuItem>,
   automationId?: string,
+  heading?: string,
 |};
 
 type State = {|
@@ -38,7 +39,7 @@ export default class Menu extends React.Component<Props, State> {
   state = { open: false };
 
   render() {
-    const { children, automationId } = this.props;
+    const { children, automationId, heading } = this.props;
 
     return (
       <Media query="(min-width: 768px)">
@@ -58,7 +59,12 @@ export default class Menu extends React.Component<Props, State> {
             </nav>
           ) : (
             <React.Fragment>
-              <Link text="Settings" href="#" onClick={this.toggle} hasMenu />
+              <Link
+                text={heading ? heading : 'Menu'}
+                href="#"
+                onClick={this.toggle}
+                hasMenu
+              />
               {this.renderOffCanvas(this.state.open)}
             </React.Fragment>
           )
@@ -86,13 +92,13 @@ export default class Menu extends React.Component<Props, State> {
   }
 
   renderOffCanvas(isOpen: boolean) {
-    const { items } = this.props;
+    const { items, heading } = this.props;
 
     return (
       <OffCanvas
         links={items.map(this.renderOffCanvasMenuItem)}
         menuVisible={isOpen}
-        heading="Settings"
+        heading={heading ? heading : 'Menu'}
         headerComponent={this.renderBackButton()}
         toggleMenu={this.toggle}
       />

--- a/components/GlobalIANavigationBar/components/Menu.js
+++ b/components/GlobalIANavigationBar/components/Menu.js
@@ -2,7 +2,12 @@
 import * as React from 'react';
 
 import styles from './Menu.module.scss';
-import Tooltip from './Tooltip.js';
+import Tooltip from './Tooltip';
+import Link from './Link';
+import Media from 'react-media';
+import { OffCanvas } from 'cultureamp-style-guide/components/OffCanvas';
+import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import backIcon from 'cultureamp-style-guide/icons/arrow-backward.svg';
 
 type MenuItem = {
   label: string,
@@ -36,18 +41,29 @@ export default class Menu extends React.Component<Props, State> {
     const { children, automationId } = this.props;
 
     return (
-      <nav className={styles.root} ref={root => (this.root = root)}>
-        <button
-          className={styles.button}
-          onClick={this.toggle}
-          aria-expanded={this.state.open}
-          data-automation-id={automationId}
-          onMouseDown={e => e.preventDefault()}
-        >
-          {children}
-        </button>
-        {this.state.open && this.renderMenu()}
-      </nav>
+      <Media query="(min-width: 768px)">
+        {matches =>
+          matches ? (
+            <nav className={styles.root} ref={root => (this.root = root)}>
+              <button
+                className={styles.button}
+                onClick={this.toggle}
+                aria-expanded={this.state.open}
+                data-automation-id={automationId}
+                onMouseDown={e => e.preventDefault()}
+              >
+                {children}
+              </button>
+              {this.state.open && this.renderMenu()}
+            </nav>
+          ) : (
+            <React.Fragment>
+              <Link text="Settings" onClick={this.toggle} />
+              {this.renderOffCanvas(this.state.open)}
+            </React.Fragment>
+          )
+        }
+      </Media>
     );
   }
 
@@ -68,6 +84,27 @@ export default class Menu extends React.Component<Props, State> {
       </div>
     );
   }
+
+  renderOffCanvas(isOpen) {
+    const { items } = this.props;
+
+    return (
+      <OffCanvas
+        links={items.map(this.renderOffCanvasMenuItem)}
+        menuVisible={isOpen}
+        heading="Settings"
+        headerComponent={this.renderBackButton()}
+      />
+    );
+  }
+
+  renderBackButton() {
+    return <IconButton icon={backIcon} onClick={this.toggle} reversed />;
+  }
+
+  renderOffCanvasMenuItem = (item: Menuitem, index: number) => {
+    return <Link key={index} text={item.label} href={item.link} />;
+  };
 
   renderMenuItem = (item: MenuItem, index: number) => {
     const { newWindow } = item;

--- a/components/GlobalIANavigationBar/constants.js
+++ b/components/GlobalIANavigationBar/constants.js
@@ -1,1 +1,1 @@
-export const TABLET_AND_UP = '(min-width: 768px)';
+export const MOBILE_QUERY = '(max-width: 768px)';

--- a/components/GlobalIANavigationBar/constants.js
+++ b/components/GlobalIANavigationBar/constants.js
@@ -1,0 +1,1 @@
+export const TABLET_AND_UP = '(min-width: 768px)';

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -1,0 +1,47 @@
+// @flow
+import * as React from 'react';
+import classNames from 'classnames';
+import styles from './OffCanvas.module.scss';
+import Header from './components/Header';
+import Menu from './components/Menu';
+import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import hamburgerIcon from 'cultureamp-style-guide/icons/hamburger.svg';
+
+type MenuType = 'Menu' | 'Settings';
+
+type State = {|
+  menuVisible: boolean,
+  badgeComponent: React.Element,
+  currentMenu: MenuType,
+|};
+
+export default class OffCanvas extends React.Component<Props, State> {
+  state = {
+    menuVisible: false,
+    currentMenu: 'Menu',
+  };
+
+  toggleMenu = () => this.setState({ menuVisible: !this.state.menuVisible });
+
+  render() {
+    return (
+      <React.Fragment>
+        <div className={styles.trigger}>
+          <IconButton icon={hamburgerIcon} onClick={this.toggleMenu} />
+        </div>
+        <div
+          className={classNames(styles.root, {
+            [styles.active]: this.state.menuVisible,
+          })}
+        >
+          <Header
+            onClose={this.toggleMenu}
+            badgeComponent={this.props.badgeComponent}
+            heading={this.state.currentMenu}
+          />
+          <Menu links={this.props.links} />
+        </div>
+      </React.Fragment>
+    );
+  }
+}

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -12,6 +12,8 @@ type Props = {|
   heading: string,
   menuVisible: boolean,
   headerComponent: React.Node,
+  footerComponent: ?React.Node,
+  toggleMenu: MouseEvent => void,
 |};
 
 export class OffCanvas extends React.Component<Props> {
@@ -33,6 +35,7 @@ export class OffCanvas extends React.Component<Props> {
           heading={this.props.heading}
         />
         <Menu links={this.props.links} />
+        {this.props.footerComponent}
       </div>
     );
   }

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import styles from './OffCanvas.module.scss';
 import Header from './components/Header';
 import Menu from './components/Menu';
-import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import IconButton from '../Button/IconButton';
 import hamburgerIcon from 'cultureamp-style-guide/icons/hamburger.svg';
-import Link from 'cultureamp-style-guide/components/GlobalIANavigationBar/components/Link';
+import Link from '../GlobalIANavigationBar/components/Link';
 
 type Props = {|
   links: Array<Link>,

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -58,7 +58,11 @@ export function withTrigger(Component: React.ComponentType<*>) {
       return (
         <React.Fragment>
           <div className={styles.trigger}>
-            <IconButton icon={hamburgerIcon} onClick={this.toggleMenu} />
+            <IconButton
+              label="Menu"
+              icon={hamburgerIcon}
+              onClick={this.toggleMenu}
+            />
           </div>
           <Component
             menuVisible={this.state.menuVisible}

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -6,6 +6,7 @@ import Header from './components/Header';
 import Menu from './components/Menu';
 import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
 import hamburgerIcon from 'cultureamp-style-guide/icons/hamburger.svg';
+import Link from 'cultureamp-style-guide/components/GlobalIANavigationBar/components/Link';
 
 type Props = {|
   links: Array<Link>,
@@ -14,6 +15,10 @@ type Props = {|
   headerComponent: React.Node,
   footerComponent: ?React.Node,
   toggleMenu: MouseEvent => void,
+|};
+
+type State = {|
+  menuVisible: boolean,
 |};
 
 export class OffCanvas extends React.Component<Props> {
@@ -41,8 +46,8 @@ export class OffCanvas extends React.Component<Props> {
   }
 }
 
-export function withTrigger(Component) {
-  return class ControlledOffCanvas extends React.Component {
+export function withTrigger(Component: React.ComponentType<*>) {
+  return class ControlledOffCanvas extends React.Component<*, State> {
     state = {
       menuVisible: false,
     };

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -7,41 +7,60 @@ import Menu from './components/Menu';
 import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
 import hamburgerIcon from 'cultureamp-style-guide/icons/hamburger.svg';
 
-type MenuType = 'Menu' | 'Settings';
-
-type State = {|
+type Props = {|
+  links: Array<Link>,
+  heading: string,
   menuVisible: boolean,
-  badgeComponent: React.Element,
-  currentMenu: MenuType,
+  headerComponent: React.Node,
 |};
 
-export default class OffCanvas extends React.Component<Props, State> {
-  state = {
-    menuVisible: false,
-    currentMenu: 'Menu',
+export class OffCanvas extends React.Component<Props> {
+  static defaultProps = {
+    links: [],
+    withTrigger: false,
   };
-
-  toggleMenu = () => this.setState({ menuVisible: !this.state.menuVisible });
 
   render() {
     return (
-      <React.Fragment>
-        <div className={styles.trigger}>
-          <IconButton icon={hamburgerIcon} onClick={this.toggleMenu} />
-        </div>
-        <div
-          className={classNames(styles.root, {
-            [styles.active]: this.state.menuVisible,
-          })}
-        >
-          <Header
-            onClose={this.toggleMenu}
-            badgeComponent={this.props.badgeComponent}
-            heading={this.state.currentMenu}
-          />
-          <Menu links={this.props.links} />
-        </div>
-      </React.Fragment>
+      <div
+        className={classNames(styles.root, {
+          [styles.active]: this.props.menuVisible,
+        })}
+      >
+        <Header
+          onClose={this.props.toggleMenu}
+          leftComponent={this.props.headerComponent}
+          heading={this.props.heading}
+        />
+        <Menu links={this.props.links} />
+      </div>
     );
   }
 }
+
+export function withTrigger(Component) {
+  return class ControlledOffCanvas extends React.Component {
+    state = {
+      menuVisible: false,
+    };
+
+    toggleMenu = () => this.setState({ menuVisible: !this.state.menuVisible });
+
+    render() {
+      return (
+        <React.Fragment>
+          <div className={styles.trigger}>
+            <IconButton icon={hamburgerIcon} onClick={this.toggleMenu} />
+          </div>
+          <Component
+            menuVisible={this.state.menuVisible}
+            toggleMenu={this.toggleMenu}
+            {...this.props}
+          />
+        </React.Fragment>
+      );
+    }
+  };
+}
+
+export default withTrigger(OffCanvas);

--- a/components/OffCanvas/OffCanvas.module.scss
+++ b/components/OffCanvas/OffCanvas.module.scss
@@ -6,6 +6,8 @@
   position: fixed;
   height: 100vh;
   width: 100%;
+  top: 0;
+  left: 0;
   transform: translateX(-100%);
   background-color: $ca-palette-ink;
   transition: transform $ca-duration-rapid $ca-ease-out;

--- a/components/OffCanvas/OffCanvas.module.scss
+++ b/components/OffCanvas/OffCanvas.module.scss
@@ -1,0 +1,22 @@
+@import '~cultureamp-style-guide/styles/color';
+@import '~cultureamp-style-guide/styles/type';
+@import '~cultureamp-style-guide/styles/animation';
+
+.root {
+  position: fixed;
+  height: 100vh;
+  width: 100%;
+  transform: translateX(-100%);
+  background-color: $ca-palette-ink;
+  transition: transform $ca-duration-rapid $ca-ease-out;
+}
+
+.active {
+  transform: translateX(0);
+}
+
+.trigger {
+  position: absolute;
+  left: $ca-grid / 2;
+  color: $ca-palette-ocean;
+}

--- a/components/OffCanvas/OffCanvas.module.scss
+++ b/components/OffCanvas/OffCanvas.module.scss
@@ -8,13 +8,17 @@
   width: 100%;
   top: 0;
   left: 0;
-  transform: translateX(-100%);
+  transform: translate3d(-120%, 0, 0);
   background-color: $ca-palette-ink;
-  transition: transform $ca-duration-rapid $ca-ease-out;
+  transition: transform $ca-duration-fast $ca-ease-out;
+  box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);
 }
 
 .active {
-  transform: translateX(0);
+  // Here we need to do a 3d transform and z-index bump
+  // in order to promote this to its own layer
+  transform: translate3d(0, 0, 0);
+  z-index: 1;
 }
 
 .trigger {

--- a/components/OffCanvas/components/Footer.js
+++ b/components/OffCanvas/components/Footer.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import styles from './Footer.module.scss';
-
-const Footer = ({ children }) => <div>{children}</div>;
-
-export default Footer;

--- a/components/OffCanvas/components/Footer.js
+++ b/components/OffCanvas/components/Footer.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import styles from './Footer.module.scss';
+
+const Footer = ({ children }) => <div>{children}</div>;
+
+export default Footer;

--- a/components/OffCanvas/components/Header.js
+++ b/components/OffCanvas/components/Header.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import styles from './Header.module.scss';
-import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import IconButton from '../../Button/IconButton';
 import closeIcon from 'cultureamp-style-guide/icons/close.svg';
 
 type Props = {|

--- a/components/OffCanvas/components/Header.js
+++ b/components/OffCanvas/components/Header.js
@@ -1,0 +1,22 @@
+// @flow
+
+import * as React from 'react';
+import styles from './Header.module.scss';
+import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
+import closeIcon from 'cultureamp-style-guide/icons/close.svg';
+
+type Props = {|
+  badgeCommponent: React.Element,
+  onClose: MouseEvent => void,
+  heading: string,
+|};
+
+const Header = ({ badgeComponent, onClose, heading }: Props) => (
+  <div className={styles.root}>
+    {badgeComponent}
+    <span className={styles.heading}>{heading}</span>
+    <IconButton icon={closeIcon} onClick={onClose} reversed />
+  </div>
+);
+
+export default Header;

--- a/components/OffCanvas/components/Header.js
+++ b/components/OffCanvas/components/Header.js
@@ -6,7 +6,7 @@ import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
 import closeIcon from 'cultureamp-style-guide/icons/close.svg';
 
 type Props = {|
-  leftComponent: React.Element,
+  leftComponent: React.Node,
   onClose: MouseEvent => void,
   heading: string,
 |};

--- a/components/OffCanvas/components/Header.js
+++ b/components/OffCanvas/components/Header.js
@@ -6,14 +6,14 @@ import IconButton from 'cultureamp-style-guide/components/Button/IconButton';
 import closeIcon from 'cultureamp-style-guide/icons/close.svg';
 
 type Props = {|
-  badgeCommponent: React.Element,
+  leftComponent: React.Element,
   onClose: MouseEvent => void,
   heading: string,
 |};
 
-const Header = ({ badgeComponent, onClose, heading }: Props) => (
+const Header = ({ leftComponent, onClose, heading }: Props) => (
   <div className={styles.root}>
-    {badgeComponent}
+    {leftComponent}
     <span className={styles.heading}>{heading}</span>
     <IconButton icon={closeIcon} onClick={onClose} reversed />
   </div>

--- a/components/OffCanvas/components/Header.js
+++ b/components/OffCanvas/components/Header.js
@@ -15,7 +15,7 @@ const Header = ({ leftComponent, onClose, heading }: Props) => (
   <div className={styles.root}>
     {leftComponent}
     <span className={styles.heading}>{heading}</span>
-    <IconButton icon={closeIcon} onClick={onClose} reversed />
+    <IconButton label="Close" icon={closeIcon} onClick={onClose} reversed />
   </div>
 );
 

--- a/components/OffCanvas/components/Header.module.scss
+++ b/components/OffCanvas/components/Header.module.scss
@@ -1,0 +1,23 @@
+@import '~cultureamp-style-guide/styles/type';
+@import '~cultureamp-style-guide/styles/color';
+
+.root {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  background-color: $ca-palette-ink;
+}
+
+.close {
+  position: absolute;
+  top: $ca-grid / 2;
+  right: $ca-grid / 2;
+}
+
+.heading {
+  @include ca-type-ideal-display;
+  @include ca-inherit-baseline;
+  color: #fff;
+}

--- a/components/OffCanvas/components/Header.module.scss
+++ b/components/OffCanvas/components/Header.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   justify-content: space-between;
   height: 60px;
-  background-color: $ca-palette-ink;
+  background-color: add-shade($ca-palette-ink, 10%);
 }
 
 .close {

--- a/components/OffCanvas/components/Menu.js
+++ b/components/OffCanvas/components/Menu.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import styles from './Menu.module.scss';
+
+const Menu = ({ links }) => {
+  const indexOfFirstSecondaryLink = links.findIndex(
+    link => link.props.secondary
+  );
+
+  return (
+    <nav className={styles.links}>
+      <ul>
+        {links.map((link, index) => (
+          <li
+            key={link.key}
+            className={classNames(styles.child, {
+              [styles.active]: link.props.active,
+              [styles.secondary]: link.props.secondary,
+              [styles.first]: index === indexOfFirstSecondaryLink,
+            })}
+          >
+            {link}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default Menu;

--- a/components/OffCanvas/components/Menu.module.scss
+++ b/components/OffCanvas/components/Menu.module.scss
@@ -1,0 +1,28 @@
+@import '~cultureamp-style-guide/styles/color';
+
+.links {
+  > ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+}
+
+.child {
+  display: flex;
+  flex: 0 0 auto;
+  text-decoration: none;
+
+  &.secondary.first {
+    margin-left: auto;
+  }
+}
+
+.otherChildren {
+  display: flex;
+  margin-left: -1px;
+}
+
+.active {
+  background-color: add-tint($ca-palette-ink, 20%);
+}

--- a/components/OffCanvas/components/Menu.module.scss
+++ b/components/OffCanvas/components/Menu.module.scss
@@ -1,6 +1,13 @@
 @import '~cultureamp-style-guide/styles/color';
+@import '~cultureamp-style-guide/styles/type';
+
+$menu-header-height: 60px;
+$menu-footer-height: 100px;
 
 .links {
+  max-height: calc(100vh - #{$menu-header-height + $menu-footer-height});
+  overflow-y: scroll;
+
   > ul {
     margin: 0;
     padding: 0;
@@ -14,7 +21,9 @@
   text-decoration: none;
 
   &.secondary.first {
-    border-top: 1px solid add-tint($ca-palette-ink, 30%);
+    border-top: 1px solid add-tint($ca-palette-ink, 10%);
+    padding-top: $ca-grid / 2;
+    margin-top: $ca-grid / 2;
   }
 }
 
@@ -24,5 +33,5 @@
 }
 
 .active {
-  background-color: add-tint($ca-palette-ink, 20%);
+  background-color: add-tint($ca-palette-ink, 10%);
 }

--- a/components/OffCanvas/components/Menu.module.scss
+++ b/components/OffCanvas/components/Menu.module.scss
@@ -14,7 +14,7 @@
   text-decoration: none;
 
   &.secondary.first {
-    margin-left: auto;
+    border-top: 1px solid add-tint($ca-palette-ink, 30%);
   }
 }
 

--- a/components/OffCanvas/index.js
+++ b/components/OffCanvas/index.js
@@ -1,0 +1,3 @@
+import OffCanvas from './OffCanvas';
+
+export default OffCanvas;

--- a/components/OffCanvas/index.js
+++ b/components/OffCanvas/index.js
@@ -1,3 +1,7 @@
-import OffCanvas from './OffCanvas';
+import ControlledOffCanvas, {
+  OffCanvas as OffCanvasComponent,
+} from './OffCanvas';
 
-export default OffCanvas;
+export const OffCanvas = OffCanvasComponent;
+
+export default ControlledOffCanvas;

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "postcss-loader": "^3.0.0",
     "prop-types": "^15.6.2",
     "react-html-id": "^0.1.4",
+    "react-media": "^1.8.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.0",
     "svg-sprite-loader": "^3.9.2",

--- a/styles/layout.scss
+++ b/styles/layout.scss
@@ -4,6 +4,7 @@ $ca-layout-max-width: 1416px;
 $ca-layout-side-padding: 24px;
 $ca-layout-content-width: 1080px;
 $ca-layout-title-block-height: 5 * $ca-grid;
+$ca-layout-title-block-mobile-height: 60px;
 $ca-layout-sidebar-width: 10 * $ca-grid;
 
 @mixin ca-margin($start: 0, $end: 0, $top: null, $bottom: null) {

--- a/styles/responsive.scss
+++ b/styles/responsive.scss
@@ -12,3 +12,15 @@ $ca-breakpoint-tablet: 1024px;
     @content;
   }
 }
+
+@mixin ca-media-tablet-and-up {
+  @media (min-width: #{$ca-breakpoint-mobile + 1px}) {
+    @content;
+  }
+}
+
+@mixin ca-media-desktop {
+  @media (min-width: #{$ca-breakpoint-tablet + 1px}) {
+    @content;
+  }
+}

--- a/styles/responsive.scss
+++ b/styles/responsive.scss
@@ -1,0 +1,14 @@
+$ca-breakpoint-mobile: 768px;
+$ca-breakpoint-tablet: 1024px;
+
+@mixin ca-media-mobile {
+  @media (max-width: #{$ca-breakpoint-mobile}) {
+    @content;
+  }
+}
+
+@mixin ca-media-tablet {
+  @media (min-width: #{$ca-breakpoint-mobile + 1px}) and (max-width: #{$ca-breakpoint-tablet}) {
+    @content;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,6 +6738,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=
+  dependencies:
+    string-convert "^0.2.0"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -9421,20 +9428,20 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.5.10, prop-types@^15.6.1, prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   integrity sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==
   dependencies:
     fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
-prop-types@^15.6.1, prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
-  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -9711,6 +9718,15 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-media@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.8.0.tgz#b86d6d62313f95d53af7d06e23d4f49adfb131d3"
+  integrity sha512-XcfqkDQj5/hmJod/kXUAZljJyMVkWrBWOkzwynAR8BXOGlbFLGBwezM0jQHtp2BrSymhf14/XrQrb3gGBnGK4g==
+  dependencies:
+    invariant "^2.2.2"
+    json2mq "^0.2.0"
+    prop-types "^15.5.10"
 
 react-test-renderer@^16.0.0-0:
   version "16.4.1"
@@ -11155,6 +11171,11 @@ strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**This adds a few things for responsive navigation:**
- An "OffCanvas" component, both controlled (with trigger) and uncontrolled (BYO trigger), that can house GlobalIANavigationBar Links and Menus.
- A set of responsive media query sass mixins.
- `react-media`, which is a helper component that abstracts over the native `matchMedia` browser API.

**A few things needed to be changed/added to the GlobalIANavigationBar component, but the API (surprisingly) didn't need to be broken in the process:**
- GlobalIANavigationBar.NavigationBar can take a `footerComponent` prop, which renders inside the top level OffCanvas menu.
- GlobalIANavigationBar.Menu can take a `heading` prop, which is what will render in the trigger link as well as the header of the nested OffCanvas menu.
