### PR TITLE
Allow async functions to be used in Button onClick

### DIFF
--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -12,7 +12,7 @@ type GenericProps = {|
   form: boolean,
   reversed: boolean,
   icon?: SvgAsset,
-  onClick?: MouseEvent => void,
+  onClick?: MouseEvent => any,
   href?: string,
   type?: 'submit' | 'reset',
   automationId?: string,


### PR DESCRIPTION
This PR updates Button types so that it's ok to use async functions in Button `onClick`s.

```
async function sendData() {
  // ...
}

function MyComponent() {
  return (
    <Button
      label="Click me"
      onClick={sendData} // <- error
    />
  );
}
```

Currently Flow errors on the `onClick={sendData}` line when `sendData` is an async function. This is because an async function implicitly returns a Promise which is not compatible with the `void` return type currently defined for a Button's `onClick`.

I changed it to `any` because the Button should not really be concerned with the return type of the function passed to it in `onClick`.

The current workaround is to wrap the async function in a function that doesn't return anything, and pass that to `onClick`.