### PR TITLE
Add reversed dropdown property back

### DIFF
--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -95,7 +95,11 @@ export default class Dropdown extends React.Component<
   };
 
   renderButtonContent = () => {
-    const { icon, label } = this.props;
+    let { icon, label } = this.props;
+
+    if (!icon && !label) {
+      icon = defaultIcon;
+    }
 
     return (
       <React.Fragment>
@@ -119,10 +123,15 @@ export default class Dropdown extends React.Component<
   };
 
   render() {
-    let { icon, label, controlAction, automationId, iconPosition, reversed } = this.props;
-    if (!icon && !label) {
-      icon = defaultIcon;
-    }
+    let {
+      icon,
+      label,
+      controlAction,
+      automationId,
+      iconPosition,
+      reversed,
+    } = this.props;
+
     const reverseIcon = iconPosition === 'end';
     const btnClass = classNames(styles.dropdownButton, {
       [styles.dropdownControlAction]: controlAction,

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -20,6 +20,7 @@ type DropdownProps = {
   menuVisible?: boolean,
   controlAction?: boolean,
   automationId?: string,
+  reversed?: boolean,
   iconPosition?: 'start' | 'end',
 };
 
@@ -118,7 +119,7 @@ export default class Dropdown extends React.Component<
   };
 
   render() {
-    let { icon, label, controlAction, automationId, iconPosition } = this.props;
+    let { icon, label, controlAction, automationId, iconPosition, reversed } = this.props;
     if (!icon && !label) {
       icon = defaultIcon;
     }
@@ -126,6 +127,7 @@ export default class Dropdown extends React.Component<
     const btnClass = classNames(styles.dropdownButton, {
       [styles.dropdownControlAction]: controlAction,
       [styles.isOpen]: this.state.isMenuVisible,
+      [styles.reversed]: reversed,
     });
     return (
       <div className={styles.dropdown}>

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -20,7 +20,7 @@ type DropdownProps = {
   menuVisible?: boolean,
   controlAction?: boolean,
   automationId?: string,
-  reversed?: boolean,
+  reversedColor?: boolean,
   iconPosition?: 'start' | 'end',
 };
 
@@ -129,14 +129,14 @@ export default class Dropdown extends React.Component<
       controlAction,
       automationId,
       iconPosition,
-      reversed,
+      reversedColor,
     } = this.props;
 
     const reverseIcon = iconPosition === 'end';
     const btnClass = classNames(styles.dropdownButton, {
       [styles.dropdownControlAction]: controlAction,
       [styles.isOpen]: this.state.isMenuVisible,
-      [styles.reversed]: reversed,
+      [styles.reversedColor]: reversedColor,
     });
     return (
       <div className={styles.dropdown}>

--- a/components/Dropdown/Dropdown.module.scss
+++ b/components/Dropdown/Dropdown.module.scss
@@ -87,6 +87,6 @@ $width: 248px;
   }
 }
 
-.reversed {
+.reversedColor {
   color: $white;
 }

--- a/components/Dropdown/__tests__/Dropdown.test.js
+++ b/components/Dropdown/__tests__/Dropdown.test.js
@@ -29,9 +29,9 @@ describe('Dropdown', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('renders reversed control action dropdown', () => {
+  test('renders reversed color control action dropdown', () => {
     const component = mount(
-      <Dropdown icon={icon} label="add" controlAction reversed />
+      <Dropdown icon={icon} label="add" controlAction reversedColor />
     );
     expect(component).toMatchSnapshot();
   });

--- a/components/Dropdown/__tests__/Dropdown.test.js
+++ b/components/Dropdown/__tests__/Dropdown.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Dropdown from '../Dropdown';
+import icon from '../../../icons/add.svg';
+
+describe('Dropdown', () => {
+  test('renders default view', () => {
+    const component = mount(<Dropdown />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders drop down with icon', () => {
+    const component = mount(<Dropdown icon={icon} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders drop down with icon and label', () => {
+    const component = mount(<Dropdown icon={icon} label="add" />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders drop down with only label', () => {
+    const component = mount(<Dropdown label="add" />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders control action dropdown', () => {
+    const component = mount(<Dropdown icon={icon} label="add" controlAction />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders reversed control action dropdown', () => {
+    const component = mount(
+      <Dropdown icon={icon} label="add" controlAction reversed />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('shows dropdown menu when clicking on the button', () => {
+    const component = mount(<Dropdown />);
+
+    component.find('.dropdownButton').simulate('click');
+
+    expect(component.find('DropdownMenu').exists()).toEqual(true);
+  });
+});

--- a/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -25,14 +25,14 @@ exports[`Dropdown renders control action dropdown 1`] = `
           title="Open menu"
         >
           <svg
-            aria-labelledby="id-3-title"
+            aria-labelledby="id-4-title"
             className="icon"
             focusable="false"
             role="img"
             viewBox="viewBox"
           >
             <title
-              id="id-3-title"
+              id="id-4-title"
             >
               Open menu
             </title>
@@ -57,14 +57,14 @@ exports[`Dropdown renders control action dropdown 1`] = `
           title="Open menu"
         >
           <svg
-            aria-labelledby="id-4-title"
+            aria-labelledby="id-5-title"
             className="icon"
             focusable="false"
             role="img"
             viewBox="viewBox"
           >
             <title
-              id="id-4-title"
+              id="id-5-title"
             >
               Open menu
             </title>
@@ -81,23 +81,6 @@ exports[`Dropdown renders control action dropdown 1`] = `
 
 exports[`Dropdown renders default view 1`] = `
 <Dropdown
-  iconPosition="start"
->
-  <div
-    className="dropdown"
-  >
-    <button
-      className="dropdownButton"
-      onClick={[Function]}
-      onMouseDown={[Function]}
-    />
-  </div>
-</Dropdown>
-`;
-
-exports[`Dropdown renders drop down with icon 1`] = `
-<Dropdown
-  icon={null}
   iconPosition="start"
 >
   <div
@@ -140,11 +123,10 @@ exports[`Dropdown renders drop down with icon 1`] = `
 </Dropdown>
 `;
 
-exports[`Dropdown renders drop down with icon and label 1`] = `
+exports[`Dropdown renders drop down with icon 1`] = `
 <Dropdown
   icon={null}
   iconPosition="start"
-  label="add"
 >
   <div
     className="dropdown"
@@ -172,6 +154,52 @@ exports[`Dropdown renders drop down with icon and label 1`] = `
           >
             <title
               id="id-2-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders drop down with icon and label 1`] = `
+<Dropdown
+  icon={null}
+  iconPosition="start"
+  label="add"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-3-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-3-title"
             >
               Open menu
             </title>
@@ -240,14 +268,14 @@ exports[`Dropdown renders reversed control action dropdown 1`] = `
           title="Open menu"
         >
           <svg
-            aria-labelledby="id-5-title"
+            aria-labelledby="id-6-title"
             className="icon"
             focusable="false"
             role="img"
             viewBox="viewBox"
           >
             <title
-              id="id-5-title"
+              id="id-6-title"
             >
               Open menu
             </title>
@@ -272,14 +300,14 @@ exports[`Dropdown renders reversed control action dropdown 1`] = `
           title="Open menu"
         >
           <svg
-            aria-labelledby="id-6-title"
+            aria-labelledby="id-7-title"
             className="icon"
             focusable="false"
             role="img"
             viewBox="viewBox"
           >
             <title
-              id="id-6-title"
+              id="id-7-title"
             >
               Open menu
             </title>

--- a/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -1,0 +1,295 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown renders control action dropdown 1`] = `
+<Dropdown
+  controlAction={true}
+  icon={null}
+  iconPosition="start"
+  label="add"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton dropdownControlAction"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-3-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-3-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+      <span
+        className="dropdownLabel"
+      >
+        add
+      </span>
+      <span
+        className="chevronIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-4-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-4-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders default view 1`] = `
+<Dropdown
+  iconPosition="start"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    />
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders drop down with icon 1`] = `
+<Dropdown
+  icon={null}
+  iconPosition="start"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-1-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-1-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders drop down with icon and label 1`] = `
+<Dropdown
+  icon={null}
+  iconPosition="start"
+  label="add"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-2-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-2-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+      <span
+        className="dropdownLabel"
+      >
+        add
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders drop down with only label 1`] = `
+<Dropdown
+  iconPosition="start"
+  label="add"
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownLabel"
+      >
+        add
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown renders reversed control action dropdown 1`] = `
+<Dropdown
+  controlAction={true}
+  icon={null}
+  iconPosition="start"
+  label="add"
+  reversed={true}
+>
+  <div
+    className="dropdown"
+  >
+    <button
+      className="dropdownButton dropdownControlAction reversed"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="dropdownIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-5-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-5-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+      <span
+        className="dropdownLabel"
+      >
+        add
+      </span>
+      <span
+        className="chevronIcon"
+      >
+        <Icon
+          icon={null}
+          inheritSize={false}
+          role="img"
+          title="Open menu"
+        >
+          <svg
+            aria-labelledby="id-6-title"
+            className="icon"
+            focusable="false"
+            role="img"
+            viewBox="viewBox"
+          >
+            <title
+              id="id-6-title"
+            >
+              Open menu
+            </title>
+            <use
+              xlinkHref="#id"
+            />
+          </svg>
+        </Icon>
+      </span>
+    </button>
+  </div>
+</Dropdown>
+`;

--- a/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
+++ b/components/Dropdown/__tests__/__snapshots__/Dropdown.test.js.snap
@@ -242,19 +242,19 @@ exports[`Dropdown renders drop down with only label 1`] = `
 </Dropdown>
 `;
 
-exports[`Dropdown renders reversed control action dropdown 1`] = `
+exports[`Dropdown renders reversed color control action dropdown 1`] = `
 <Dropdown
   controlAction={true}
   icon={null}
   iconPosition="start"
   label="add"
-  reversed={true}
+  reversedColor={true}
 >
   <div
     className="dropdown"
   >
     <button
-      className="dropdownButton dropdownControlAction reversed"
+      className="dropdownButton dropdownControlAction reversedColor"
       onClick={[Function]}
       onMouseDown={[Function]}
     >

--- a/guide/src/pages/components/Dropdown/_presets.js
+++ b/guide/src/pages/components/Dropdown/_presets.js
@@ -70,7 +70,7 @@ const presets = [
   {
     name: 'Reversed Control action',
     node: (
-      <Dropdown label="Print" icon={print} controlAction={true} reversed>
+      <Dropdown label="Print" icon={print} controlAction={true} reversedColor>
         {menuList}
       </Dropdown>
     ),


### PR DESCRIPTION
This PR is about adding the reversed property back to this component. I added this property a while back https://github.com/cultureamp/cultureamp-style-guide/pull/167 but I think it got removed accidentally.

To prevent this in the future, I also added a couple of jest tests to ensure that this won't get deleted again :)

I also noticed that the default icon is not being displayed in the dropdown component when the icon and the label are not present. So this PR includes this fix too :)