### PR TITLE
fix(GlobalIALayout): Fix content area width when there is no sidebar

### DIFF
--- a/components/GlobalIALayout/_styles.scss
+++ b/components/GlobalIALayout/_styles.scss
@@ -128,7 +128,7 @@
 
     @media (min-width: 480px) {
       min-width: auto;
-      max-width: 900px;
+      max-width: $ca-layout-content-width;
     }
   }
 }


### PR DESCRIPTION
This fixes the content area max-width when there is **no sidebar**. The current value of `900px` appears to be a leftover/oversight because it actually results in less usable space compared to when there is a sidebar.

With sidebar + content.
Total width = 1416

![screen shot 2018-11-30 at 3 37 28 pm](https://user-images.githubusercontent.com/4900094/49270760-ebb0db80-f4be-11e8-843f-1b43c1494939.png)

Without sidebar.
Total width = 900

![screen shot 2018-11-30 at 3 37 46 pm](https://user-images.githubusercontent.com/4900094/49270782-100cb800-f4bf-11e8-97f9-2626a84aafe0.png)

I've checked with the designers who agreed that content area should be `1080px` as defined by `$ca-layout-content-width`.

In Murmur, all uses of `%global-ia-content` have an accompanying sidebar, so this issue hasn't yet shown itself.