### PR TITLE
Fix off canvas menu overflow

### DIFF
--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -4,8 +4,6 @@ import classNames from 'classnames';
 import styles from './OffCanvas.module.scss';
 import Header from './components/Header';
 import Menu from './components/Menu';
-import IconButton from '../Button/IconButton';
-import hamburgerIcon from 'cultureamp-style-guide/icons/hamburger.svg';
 import Link from '../GlobalIANavigationBar/components/Link';
 
 type Props = {|

--- a/components/OffCanvas/OffCanvas.js
+++ b/components/OffCanvas/OffCanvas.js
@@ -96,13 +96,12 @@ function withTrigger(Component: React.ComponentType<*>) {
         <OffCanvasContext.Consumer>
           {({ toggleVisibleMenu }) => (
             <React.Fragment>
-              <div className={styles.trigger}>
-                <IconButton
-                  label="Menu"
-                  icon={hamburgerIcon}
-                  onClick={() => toggleVisibleMenu(this.props.menuId)}
-                />
-              </div>
+              <button
+                className={styles.trigger}
+                onClick={() => toggleVisibleMenu(this.props.menuId)}
+              >
+                <span className={styles.hamburger} />
+              </button>
               <Component {...this.props} />
             </React.Fragment>
           )}

--- a/components/OffCanvas/OffCanvas.module.scss
+++ b/components/OffCanvas/OffCanvas.module.scss
@@ -1,6 +1,11 @@
 @import '~cultureamp-style-guide/styles/color';
 @import '~cultureamp-style-guide/styles/type';
 @import '~cultureamp-style-guide/styles/animation';
+@import '~cultureamp-style-guide/components/Button/styles';
+
+$hamburger-width: 18px;
+$hamburger-layer-height: 2px;
+$hamburger-layer-spacing: 3px;
 
 .root {
   position: fixed;
@@ -22,8 +27,37 @@
 }
 
 .trigger {
+  @include button-reset;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: $ca-grid;
+  left: $ca-grid / 2;
   color: $ca-palette-ocean;
+}
+
+.hamburger {
+  width: $hamburger-width;
+  height: $hamburger-layer-height;
+  background-color: add-tint($ca-palette-ocean, 30%);
+  position: relative;
+  display: block;
+
+  &::before {
+    content: '';
+    width: $hamburger-width;
+    height: $hamburger-layer-height;
+    position: absolute;
+    top: $hamburger-layer-height + $hamburger-layer-spacing;
+    left: 0;
+    background-color: add-tint($ca-palette-ocean, 30%);
+  }
+
+  &::after {
+    content: '';
+    width: $hamburger-width;
+    height: $hamburger-layer-height;
+    position: absolute;
+    top: ($hamburger-layer-height + $hamburger-layer-spacing) * 2;
+    left: 0;
+    background-color: add-tint($ca-palette-ocean, 30%);
+  }
 }

--- a/components/OffCanvas/components/Menu.module.scss
+++ b/components/OffCanvas/components/Menu.module.scss
@@ -7,6 +7,7 @@ $menu-footer-height: 100px;
 .links {
   max-height: calc(100vh - #{$menu-header-height + $menu-footer-height});
   overflow-y: scroll;
+  overflow-x: hidden;
 
   > ul {
     margin: 0;


### PR DESCRIPTION
The off canvas menu exhibited some extra horizontal scrolling on iOS mobile safari.
The change in `components/OffCanvas/components/Menu.module.scss` fixes that.
There is also a refactor of the hamburger so that it's size and color can more easily be adjusted.