### PR TITLE
Front end/fix button overflow

### DIFF
--- a/components/Button/Button.elm
+++ b/components/Button/Button.elm
@@ -184,7 +184,8 @@ viewIconFor configValue forPosition =
     if configValue.iconPosition == forPosition then
         case configValue.icon of
             Just svgAsset ->
-                Icon.view Icon.presentation svgAsset
+                span [ styles.class .iconWrapper ]
+                    [ Icon.view Icon.presentation svgAsset ]
 
             Nothing ->
                 text ""
@@ -213,6 +214,7 @@ styles =
         , content = "content"
         , label = "label"
         , fullWidth = "fullWidth"
+        , iconWrapper = "iconWrapper"
         }
 
 

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -31,7 +31,8 @@ $caButton-verticalPaddingForm: calc(
   @include button-reset;
   @include ca-type-ideal-button;
 
-  display: inline-block;
+  display: flex;
+  align-items: center;
   box-sizing: border-box;
   min-height: $caButton-height;
   border: $caButton-border-width solid;

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -7,7 +7,10 @@ $caButton-border-width: 1px;
 $caButton-focus-border-width: 2px;
 $caButton-height: $ca-grid * 2;
 $caButton-formHeight: $ca-grid * 5/3;
-$caButton-vertical-padding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
+$caButton-verticalPadding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
+$caButton-verticalPaddingForm: calc(
+  #{$ca-grid / 3} - #{$caButton-border-width}
+);
 
 // reset user agent syles for button elment type
 @mixin button-reset {
@@ -86,7 +89,7 @@ $caButton-vertical-padding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
 }
 
 %caButtonForm {
-  height: $caButton-formHeight;
+  min-height: $caButton-formHeight;
 }
 
 %caButtonPrimary,
@@ -302,27 +305,45 @@ $caButton-vertical-padding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
 
   // Padding applied to button content and not button so that mix-blend-mode
   // effects can be applied to the button content but not the button border
-  padding: $caButton-vertical-padding
+  padding: $caButton-verticalPadding
     calc(#{$ca-grid * 1} - #{$caButton-border-width});
 
   %caButtonSecondary & {
-    padding: $caButton-vertical-padding
-      calc(#{$ca-grid * 0.5} - #{$caButton-border-width});
+    padding-left: calc(#{$ca-grid * 0.5} - #{$caButton-border-width});
+    padding-right: calc(#{$ca-grid * 0.5} - #{$caButton-border-width});
+  }
+
+  %caButtonForm & {
+    padding-top: $caButton-verticalPaddingForm;
+    padding-bottom: $caButton-verticalPaddingForm;
   }
 
   @supports (mix-blend-mode: screen) {
     %caButtonReversed%caButtonPrimary & {
-      padding: $caButton-vertical-padding ($ca-grid * 1);
+      padding-left: ($ca-grid * 1);
+      padding-right: ($ca-grid * 1);
     }
   }
 
   :global(.js-focus-visible) %caButton:global(.focus-visible) & {
-    padding: $caButton-vertical-padding
+    padding: calc(#{$ca-grid / 2} - #{$caButton-focus-border-width})
       calc(#{$ca-grid * 1} - #{$caButton-focus-border-width});
   }
 
   :global(.js-focus-visible) %caButtonSecondary:global(.focus-visible) & {
-    padding: $caButton-vertical-padding
+    padding: calc(#{$ca-grid / 2} - #{$caButton-focus-border-width})
+      calc(#{$ca-grid * 0.5} - #{$caButton-focus-border-width});
+  }
+
+  :global(.js-focus-visible) %caButton%caButtonForm:global(.focus-visible) & {
+    padding: calc(#{$ca-grid / 3} - #{$caButton-focus-border-width})
+      calc(#{$ca-grid * 1} - #{$caButton-focus-border-width});
+  }
+
+  :global(.js-focus-visible)
+    %caButtonSecondary%caButtonForm:global(.focus-visible)
+    & {
+    padding: calc(#{$ca-grid / 3} - #{$caButton-focus-border-width})
       calc(#{$ca-grid * 0.5} - #{$caButton-focus-border-width});
   }
 }

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -349,6 +349,12 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonLabel {
+  // This line height equates to 3/4 of a grid unit - so 18px. We set this
+  // here rather than in ca-type-ideal-button because changing the type style
+  // changes the baseline grid alignment for all buttons. Changing it here keeps
+  // the baseline alignment correct for single line buttons.
+  line-height: 1;
+
   &:only-child {
     margin: 0 $ca-grid / 2;
 

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -7,6 +7,7 @@ $caButton-border-width: 1px;
 $caButton-focus-border-width: 2px;
 $caButton-height: $ca-grid * 2;
 $caButton-formHeight: $ca-grid * 5/3;
+$caButton-vertical-padding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
 
 // reset user agent syles for button elment type
 @mixin button-reset {
@@ -29,7 +30,7 @@ $caButton-formHeight: $ca-grid * 5/3;
 
   display: inline-block;
   box-sizing: border-box;
-  height: $caButton-height;
+  min-height: $caButton-height;
   border: $caButton-border-width solid;
   border-radius: $ca-border-radius;
   // looking for padding? See %caButtonContent
@@ -301,24 +302,28 @@ $caButton-formHeight: $ca-grid * 5/3;
 
   // Padding applied to button content and not button so that mix-blend-mode
   // effects can be applied to the button content but not the button border
-  padding: 0 calc(#{$ca-grid * 1} - #{$caButton-border-width});
+  padding: $caButton-vertical-padding
+    calc(#{$ca-grid * 1} - #{$caButton-border-width});
 
   %caButtonSecondary & {
-    padding: 0 calc(#{$ca-grid * 0.5} - #{$caButton-border-width});
+    padding: $caButton-vertical-padding
+      calc(#{$ca-grid * 0.5} - #{$caButton-border-width});
   }
 
   @supports (mix-blend-mode: screen) {
     %caButtonReversed%caButtonPrimary & {
-      padding: 0 ($ca-grid * 1);
+      padding: $caButton-vertical-padding ($ca-grid * 1);
     }
   }
 
   :global(.js-focus-visible) %caButton:global(.focus-visible) & {
-    padding: 0 calc(#{$ca-grid * 1} - #{$caButton-focus-border-width});
+    padding: $caButton-vertical-padding
+      calc(#{$ca-grid * 1} - #{$caButton-focus-border-width});
   }
 
   :global(.js-focus-visible) %caButtonSecondary:global(.focus-visible) & {
-    padding: 0 calc(#{$ca-grid * 0.5} - #{$caButton-focus-border-width});
+    padding: $caButton-vertical-padding
+      calc(#{$ca-grid * 0.5} - #{$caButton-focus-border-width});
   }
 }
 
@@ -338,6 +343,10 @@ $caButton-formHeight: $ca-grid * 5/3;
   &:not(:last-child) {
     @include ca-margin($end: 0.5em);
   }
+}
+
+%caButtonIconWrapper {
+  height: 20px;
 }
 
 %caButtonIconButton {

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -375,6 +375,7 @@ $caButton-verticalPaddingForm: calc(
 
 %caButtonIconWrapper {
   height: 20px;
+  align-self: flex-start;
 }
 
 %caButtonIconButton {

--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -136,5 +136,9 @@ function renderContent(props: Props) {
 }
 
 function renderIcon(icon: SvgAsset) {
-  return <Icon icon={icon} role="presentation" />;
+  return (
+    <span className={styles.iconWrapper}>
+      <Icon icon={icon} role="presentation" />
+    </span>
+  );
 }

--- a/components/Button/components/GenericButton.module.scss
+++ b/components/Button/components/GenericButton.module.scss
@@ -80,3 +80,7 @@
     justify-content: center;
   }
 }
+
+.iconWrapper {
+  @extend %caButtonIconWrapper;
+}

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -140,6 +140,15 @@ const buttonPresets = [
     darkBackground: true,
   },
   {
+    name: 'Multiple buttons',
+    node: (
+      <div>
+        <Button label="Save" primary automationId="demo-button-1" />
+        <Button label="Exit" automationId="demo-button-2" />
+      </div>
+    ),
+  },
+  {
     name: 'Type Submit',
     node: <Button label="Label" type="submit" />,
   },

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -53,10 +53,6 @@ const buttonPresets = [
     node: <Button label="Label" disabled />,
   },
   {
-    name: 'Form',
-    node: <Button label="Label" form />,
-  },
-  {
     name: 'Primary',
     node: <Button label="Label" primary />,
   },
@@ -106,6 +102,41 @@ const buttonPresets = [
   {
     name: 'Primary Reversed Disabled',
     node: <Button label="Label" primary reversed disabled />,
+    darkBackground: true,
+  },
+  {
+    name: 'Form',
+    node: <Button label="Label" form />,
+  },
+  {
+    name: 'Form (Overflowing text)',
+    node: (
+      <div style={{ width: 120 }}>
+        <Button
+          form
+          icon={configureIcon}
+          label="Passez au rapport de synthèse"
+          automationId="demo-button"
+        />
+      </div>
+    ),
+  },
+  {
+    name: 'Form Primary',
+    node: <Button primary label="Label" form />,
+  },
+  {
+    name: 'Form Secondary',
+    node: <Button secondary label="Label" form />,
+  },
+  {
+    name: 'Form Reversed',
+    node: <Button label="Label" reversed form />,
+    darkBackground: true,
+  },
+  {
+    name: 'Form Primary Reversed',
+    node: <Button primary label="Label" reversed form />,
     darkBackground: true,
   },
   {

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -39,7 +39,7 @@ const buttonPresets = [
   {
     name: 'Overflowing text',
     node: (
-      <div style={{ width: 120 }}>
+      <div style={{ width: 220 }}>
         <Button
           icon={configureIcon}
           label="Passez au rapport de synthèse"
@@ -111,7 +111,7 @@ const buttonPresets = [
   {
     name: 'Form (Overflowing text)',
     node: (
-      <div style={{ width: 120 }}>
+      <div style={{ width: 220 }}>
         <Button
           form
           icon={configureIcon}

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -37,6 +37,18 @@ const buttonPresets = [
     node: <Button label="Configure" icon={configureIcon} iconPosition="end" />,
   },
   {
+    name: 'Overflowing text',
+    node: (
+      <div style={{ width: 120 }}>
+        <Button
+          icon={configureIcon}
+          label="Passez au rapport de synthèse"
+          automationId="demo-button"
+        />
+      </div>
+    ),
+  },
+  {
     name: 'Disabled',
     node: <Button label="Label" disabled />,
   },

--- a/guide/src/pages/components/Button/button.md
+++ b/guide/src/pages/components/Button/button.md
@@ -30,6 +30,8 @@ A button!
 
 - flip the direction of arrow icons when the user is using a right-to-left language.
 
+- either be hyperlinks (if they navigate to a new page and can be opened in a new tab) or a button element.
+
 </TipCard>
 <TipCard title="Buttons should not…" type="warning">
 

--- a/guide/src/pages/components/Button/button.md
+++ b/guide/src/pages/components/Button/button.md
@@ -4,6 +4,7 @@ imports:
   Elm: ./ButtonDemo.elm
   IntroParagraph: components/IntroParagraph.js
   buttonPresets: ./_buttonPresets.js
+  '{TipContainer,TipCard}': components/tip-card
 ---
 
 # Button
@@ -15,3 +16,26 @@ A button!
 </IntroParagraph>
 
 <Demo presets={buttonPresets} elm={Elm.Elm.Button.ButtonDemo} />
+
+## Best practices
+
+<TipContainer>
+<TipCard title="Buttons should…" type="tip">
+
+- be 2 to 3 words long.
+
+- put verbs first; use only verbs where possible.
+
+- be sentence case.
+
+- flip the direction of arrow icons when the user is using a right-to-left language.
+
+</TipCard>
+<TipCard title="Buttons should not…" type="warning">
+
+- use long phrases.
+
+- have finishing punctuation.
+
+</TipCard>
+</TipContainer>


### PR DESCRIPTION
- [x] Ensure docs encourage two-three words
- [x] Line height 18px
- [x] Ensure links (`<a>` rather than `<button>`) sit text correctly on the grid
- [x] Icon should sit flush with the first line of text

Before:

![image](https://user-images.githubusercontent.com/315158/50556693-67e54b80-0d17-11e9-94be-c6f5af5cda8d.png)

During (before design review):

![image](https://user-images.githubusercontent.com/315158/50556701-81869300-0d17-11e9-96c3-a33b758ae35a.png)

After (squashed line height, icon aligned with first row):

![image](https://user-images.githubusercontent.com/315158/50871798-c1283b80-13f7-11e9-970a-97254aa9f88b.png)
