### PR TITLE
docs(AnimationImportExample.js): fixed incorrect import reference

### DIFF
--- a/guide/src/pages/guides/animation/examples/AnimationImportExample.scss
+++ b/guide/src/pages/guides/animation/examples/AnimationImportExample.scss
@@ -1,1 +1,1 @@
-@import '~cultureamp-style-guide/styles/animations';
+@import '~cultureamp-style-guide/styles/animation';


### PR DESCRIPTION
When using /animations reference webpack fails to find the correct path. /animation points to the
correct scss file.