### PR TITLE
Fix/button mix blend mode visual regression

### DIFF
--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -244,52 +244,6 @@ $caButton-verticalPaddingForm: calc(
         background: add-alpha($white, 90%);
         border-color: transparent;
       }
-
-      // knockout text effect (background visible through text) for supported browsers
-      @supports (mix-blend-mode: lighten) {
-        // add background to %caButtonContent instead, so we can mix-blend-mode the button's background but not its border (for solid focus ring)
-        background: transparent;
-        border-width: 0;
-        overflow: hidden;
-
-        %caButtonContent {
-          mix-blend-mode: screen;
-          background: $white;
-          color: $black; // mix-blend-mode makes this transparent
-        }
-
-        &:hover {
-          background: transparent;
-
-          %caButtonContent {
-            // mix-blend-mode makes this 95% alpha white
-            background: add-tint($black, 95%);
-          }
-        }
-
-        :global(.js-focus-visible) &:global(.focus-visible):not(:active) {
-          background: transparent;
-
-          %caButtonContent {
-            // mix-blend-mode makes this 95% alpha white
-            background: add-tint($black, 95%);
-          }
-        }
-
-        &:active {
-          background: transparent;
-
-          // translateY interferes with mix-blend-mode, so use margin instead
-          margin-top: 1px;
-          margin-bottom: -1px;
-          transform: none;
-
-          %caButtonContent {
-            // mix-blend-mode makes this 90% alpha white
-            background: add-tint($black, 90%);
-          }
-        }
-      }
     }
 
     &:disabled {
@@ -317,13 +271,6 @@ $caButton-verticalPaddingForm: calc(
   %caButtonForm & {
     padding-top: $caButton-verticalPaddingForm;
     padding-bottom: $caButton-verticalPaddingForm;
-  }
-
-  @supports (mix-blend-mode: screen) {
-    %caButtonReversed%caButtonPrimary & {
-      padding-left: ($ca-grid * 1);
-      padding-right: ($ca-grid * 1);
-    }
   }
 
   :global(.js-focus-visible) %caButton:global(.focus-visible) & {
@@ -399,7 +346,6 @@ $caButton-verticalPaddingForm: calc(
           %caButtonContent {
             color: white;
             background: none;
-            mix-blend-mode: initial;
           }
         }
       }

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -258,8 +258,6 @@ $caButton-verticalPaddingForm: calc(
   display: flex;
   align-items: center;
 
-  // Padding applied to button content and not button so that mix-blend-mode
-  // effects can be applied to the button content but not the button border
   padding: $caButton-verticalPadding
     calc(#{$ca-grid * 1} - #{$caButton-border-width});
 

--- a/components/Button/_styles.scss
+++ b/components/Button/_styles.scss
@@ -6,6 +6,7 @@
 $caButton-border-width: 1px;
 $caButton-focus-border-width: 2px;
 $caButton-height: $ca-grid * 2;
+$caButtonIcon-height: 20px;
 $caButton-formHeight: $ca-grid * 5/3;
 $caButton-verticalPadding: calc(#{$ca-grid / 2} - #{$caButton-border-width});
 $caButton-verticalPaddingForm: calc(
@@ -319,7 +320,7 @@ $caButton-verticalPaddingForm: calc(
 }
 
 %caButtonIconWrapper {
-  height: 20px;
+  height: $caButtonIcon-height;
   align-self: flex-start;
 }
 
@@ -360,6 +361,11 @@ $caButton-verticalPaddingForm: calc(
     justify-content: center;
     width: 100%;
     padding: 0;
+    // IE 10/11 workaround to fix vertical centering of icon
+    margin: calc(
+        (((#{$caButton-height}) - #{$caButtonIcon-height}) / 2) - #{$caButton-border-width}
+      )
+      0;
   }
 
   &%caButtonForm {

--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -104,6 +104,10 @@ function renderLink(props: Props) {
 }
 
 function buttonClass(props: Props) {
+  if (props.reversed && !props.reverseColor) {
+    console.warn('please provide a fallback colour for revered buttons');
+  }
+
   const variantClass =
     (props.destructive && styles.destructive) ||
     (props.primary && styles.primary) ||

--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -105,7 +105,7 @@ function renderLink(props: Props) {
 
 function buttonClass(props: Props) {
   if (props.reversed && !props.reverseColor) {
-    console.warn('please provide a fallback colour for revered buttons');
+    console.warn('please provide a fallback colour for reversed buttons');
   }
 
   const variantClass =

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -96,7 +96,7 @@ const buttonPresets = [
   },
   {
     name: 'Primary Reversed',
-    node: <Button label="Label" primary reversed reverseColor="ocean" />,
+    node: <Button label="Label" primary reversed />,
     darkBackground: true,
   },
   {

--- a/guide/src/pages/components/Button/_buttonPresets.js
+++ b/guide/src/pages/components/Button/_buttonPresets.js
@@ -96,7 +96,7 @@ const buttonPresets = [
   },
   {
     name: 'Primary Reversed',
-    node: <Button label="Label" primary reversed />,
+    node: <Button label="Label" primary reversed reverseColor="ocean" />,
     darkBackground: true,
   },
   {


### PR DESCRIPTION
This commit fixes the visual regression issue for reversed primary buttons. Opportunity was taken to remove `mix-blend-mode` as this simplifies button styling and eliminates some of the bugs that were being caused because of this e.g. animations.

A future improvement would be to simplify how padding is calculated on buttons and move it to the button element. I avoided this in this PR as I think it is important to address the defect as quickly as possible.

** I am going to create a seperate PR for Murmur against which I will run Visual regression tests. There are a number of implementations that do not specify a fallback colour so they will need to be updated in this PR as well. **

<img width="896" alt="screen shot 2019-01-21 at 9 18 50 pm" src="https://user-images.githubusercontent.com/1480083/51468438-159dc480-1dc3-11e9-87ff-9d02103cd7fb.png">

<img width="900" alt="screen shot 2019-01-21 at 9 18 43 pm" src="https://user-images.githubusercontent.com/1480083/51468437-15052e00-1dc3-11e9-9a5b-00ef99e9a4bb.png">
