### PR TITLE
fix(button): Remove console.warn for missing reverseColor prop

### DIFF
--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -107,10 +107,6 @@ function renderLink(props: Props) {
 }
 
 function buttonClass(props: Props) {
-  if (props.reversed && !props.reverseColor) {
-    console.warn('please provide a fallback colour for reversed buttons');
-  }
-
   const variantClass =
     (props.destructive && styles.destructive) ||
     (props.primary && styles.primary) ||


### PR DESCRIPTION
Currently, if we use a Button component with the `reversed` prop but do not pass in a `reversedColor` prop, the component logs a `console.warn` message. This is just noise for the developer and clutters up Bugsnag with minimal benefit. This PR removes the message clean up the noise while we work towards a more sensible type-checked approach.