### PR TITLE
feat(kaizen): add inline prop option to Text component

### DIFF
--- a/components/Text/Text.elm
+++ b/components/Text/Text.elm
@@ -9,6 +9,7 @@ module Text.Text exposing
     , h5
     , h6
     , inheritBaseline
+    , inline
     , label
     , p
     , style
@@ -46,11 +47,11 @@ import Html exposing (Html)
 
 view : Config msg -> List (Html.Html msg) -> Html.Html msg
 view (Config config) children =
-    config.tag [ className config.tag config.style config.inheritBaseline ] children
+    config.tag [ className config.tag config.style config.inheritBaseline config.inline ] children
 
 
-className : Element msg -> TypeStyle -> Bool -> Html.Attribute msg
-className tag typeStyle shouldInheritBaseline =
+className : Element msg -> TypeStyle -> Bool -> Bool -> Html.Attribute msg
+className tag typeStyle shouldInheritBaseline shouldInline =
     let
         styleClass =
             case typeStyle of
@@ -102,6 +103,7 @@ className tag typeStyle shouldInheritBaseline =
     styles.classList
         [ ( styleClass, True )
         , ( .inheritBaseline, shouldInheritBaseline )
+        , ( .inline, shouldInline )
         ]
 
 
@@ -123,6 +125,7 @@ styles =
         , controlAction = "controlAction"
         , button = "button"
         , inheritBaseline = "inheritBaseline"
+        , inline = "inline"
         }
 
 
@@ -138,6 +141,7 @@ type alias ConfigValue msg =
     { tag : Element msg
     , style : TypeStyle
     , inheritBaseline : Bool
+    , inline : Bool
     }
 
 
@@ -168,6 +172,7 @@ defaultConfig =
     { tag = Html.div
     , style = DefaultStyle
     , inheritBaseline = False
+    , inline = False
     }
 
 
@@ -223,6 +228,11 @@ label =
 inheritBaseline : Bool -> Config msg -> Config msg
 inheritBaseline value (Config config) =
     Config { config | inheritBaseline = value }
+
+
+inline : Bool -> Config msg -> Config msg
+inline value (Config config) =
+    Config { config | inline = value }
 
 
 style : TypeStyle -> Config msg -> Config msg

--- a/components/Text/Text.js
+++ b/components/Text/Text.js
@@ -22,6 +22,7 @@ type TextProps = {
     | 'control-action'
     | 'button',
   inheritBaseline: boolean,
+  inline: boolean,
   children: React.Node,
 };
 
@@ -31,6 +32,7 @@ const Text = (props: TextProps) => {
     <Tag
       className={classNames(styles[props.style], {
         [styles.inheritBaseline]: props.inheritBaseline,
+        [styles.inline]: props.inline,
       })}
     >
       {props.children}
@@ -41,6 +43,7 @@ const Text = (props: TextProps) => {
 Text.defaultProps = {
   style: 'default-style',
   inheritBaseline: false,
+  inline: false,
 };
 
 Text.displayName = 'Text';

--- a/components/Text/Text.module.scss
+++ b/components/Text/Text.module.scss
@@ -89,6 +89,12 @@ p.default-style {
   @include ca-inherit-baseline;
 }
 
+// Required for aligning text alongside other elements e.g. Button
+.inline.inline {
+  display: inline-flex;
+  margin-bottom: 0;
+}
+
 // Alias classes for Elm CSS modules
 .defaultStyle {
   composes: default-style;

--- a/guide/src/pages/components/Text/_presets.js
+++ b/guide/src/pages/components/Text/_presets.js
@@ -19,6 +19,23 @@ const presets = [
     name: 'H2',
     node: <Text tag="h2">This is a Title (H2)</Text>,
   },
+
+  {
+    name: 'H2 (inline)',
+    node: (
+      <div>
+        <Text tag="h2" inline={true}>
+          This is a Title (H2)
+        </Text>
+        <Text tag="h2" inline={true}>
+          This is a Title (H2)
+        </Text>
+        <Text tag="h2" inline={true}>
+          This is a Title (H2)
+        </Text>
+      </div>
+    ),
+  },
   {
     name: 'H3',
     node: <Text tag="h3">This is a Display Heading (H3)</Text>,
@@ -124,7 +141,8 @@ const presets = [
     node: (
       <Text tag="div" style="notification">
         Div with "Notification" styles
-        <br />that have a smaller line-height
+        <br />
+        that have a smaller line-height
       </Text>
     ),
   },


### PR DESCRIPTION
New `inline` prop removes margin from text and sets display to `inline-flex`. Useful for aligning headings with other elements e.g. Button

![screen shot 2019-02-26 at 3 57 14 pm](https://user-images.githubusercontent.com/1480083/53388445-4fc03e80-39df-11e9-9120-bab970dd7af4.png)
