### PR TITLE
Allow type="button" attribute for buttons

### DIFF
--- a/components/Button/components/GenericButton.js
+++ b/components/Button/components/GenericButton.js
@@ -17,7 +17,7 @@ type GenericProps = {|
   onClick?: MouseEvent => any,
   href?: string,
   newTabAndIUnderstandTheAccessibilityImplications?: boolean,
-  type?: 'submit' | 'reset',
+  type?: 'submit' | 'reset' | 'button',
   automationId?: string,
 |};
 
@@ -48,6 +48,7 @@ GenericButton.defaultProps = {
   primary: false,
   secondary: false,
   newTabAndIUnderstandTheAccessibilityImplications: false,
+  type: 'button',
 };
 
 export default function GenericButton(props: Props) {


### PR DESCRIPTION
Here's a tiny thing. :)

This attribute is useful for buttons with custom behaviour that aren't meant for submitting form data (which is the default behaviour).

It prevents buttons from accidentally submitting a form element they happen to be in, without having to prevent default etc in your code.

MDN has a bit more info:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type