### PR TITLE
Don't run semantic release anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
 - yarn flow
 - yarn jest
 - bin/buildSite
-- yarn semantic-release
 deploy:
   provider: pages
   local-dir: guide/public


### PR DESCRIPTION
The builds are failing because the NPM tokens are old, and we don't autopublishing anymore,
so I'm just removing the semantic-release build step.

Dead weight CUT.